### PR TITLE
Fix Storage Path Not Resolving ~ as Home Directory.

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"github.com/mitchellh/go-homedir"
 	"github.com/syndtr/goleveldb/leveldb"
 	"path/filepath"
 )
@@ -11,7 +12,13 @@ type Store struct {
 }
 
 func NewStore(name string, storagePath string) (store *Store, err error) {
-	db, err := leveldb.OpenFile(filepath.Join(storagePath, name), nil)
+	// Expand '~' as the full home directory path if appropriate
+	path, err := homedir.Expand(storagePath)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := leveldb.OpenFile(filepath.Join(path, name), nil)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
@timoman @skuehn @ericchang: Here's the bug that @timoman's "friend" ran into a while back. It was with some other tool but with the same underlying issue. 

In this case, if someone was using something like `~/botstorage/`, the resulting files would get created as `./~/botstorage` instead of resolving the `~` as the `home` directory. 

This fixes it so that no more evil `~` get inadvertently created.