### PR TITLE
Migrate Slackscot From james-bowman/slack To nlopes/slack API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,37 @@
 Slackscot
 =========
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/alexandre-normand/slackscot)](https://goreportcard.com/report/github.com/alexandre-normand/slackscot)
 [![GoDoc](https://godoc.org/github.com/alexandre-normand/slackscot?status.svg)](https://godoc.org/github.com/alexandre-normand/slackscot)
 [![Build Status](https://travis-ci.org/alexandre-normand/slackscot.svg)](https://travis-ci.org/alexandre-normand/slackscot) 
 
-Slackscot is a simple [slack](https://slack.com) bot written in Go. It uses [Slack RTM API Integration](https://github.com/james-bowman/slack) written by [James Bowman](https://github.com/james-bowman). The core functionality of the bot is also heavily inspired by [talbot](https://github.com/james-bowman/talbot), also written by [James Bowman](https://github.com/james-bowman). 
+Slackscot is a simple [slack](https://slack.com) bot written in Go. It uses [Norberto Lopes](https://github.com/nlopes)'s [Slack API Integration](https://github.com/nlopes/slack) found at [https://github.com/nlopes/slack](https://github.com/nlopes/slack). The core functionality of the bot is previously used [James Bowman](https://github.com/james-bowman)'s [Slack RTM API integration](https://github.com/james-bowman/slack) and was heavily inspired by [talbot](https://github.com/james-bowman/talbot), also written by [James Bowman](https://github.com/james-bowman). 
 
 The Name
 --------
-The first concrete bot implementation using this code was [youppi](https://github.com/alexandre-normand/youppi), named after the [great mascot](https://en.wikipedia.org/wiki/Youppi!) of the Montreal Expos and, when the Expos left Montreal, the Montreal Canadiens. Slackscot is a play on words for `mascot` because who doesn't want a hairy colorful friend as company on slack? 
+The first concrete bot implementation using this code was [youppi](https://github.com/alexandre-normand/youppi), named after the [great mascot](https://en.wikipedia.org/wiki/Youppi!) of the Montreal Expos and, when the Expos left Montreal, the Montreal Canadiens. `Slackscot` is a variation on the expected theme of `slackbot` with the implication that this is the core to _more_ than just a regular `bot`. You know, a friendly company mascot that hangs out on your `slack`. 
 
 Features
 --------
 
 * Simple store API for persistence. It's basic a basic string key/string value thing.
 * Basic config interface with slack token and storage path. 
-* A few basic extension bundles in [brain](brain). 
+* Plugin interface that is a logical grouping of one or many commands and "hear actions" (listeners). 
+
+Concepts
+--------
+
+* Commands: commands are well-defined actions with a format. `Slackscot` handles all direct messages as implicit commands as well as `@mention <command>` on channels. Responses to commands are directed to the person who
+  invoked it.
+* Hear actions: those are listeners that can potentially match on any message sent on channels that `slackscot` is a member of. This can include actions that will randomly generate a response. Note that responses
+  are not automatically directed to the person who authored the message triggering the response (although an implementation is free to use the user id of the triggering message if desired). 
 
 How to use
 ----------
-Slackscot provides the pieces to make your mascot but you'll have to assemble them for it to come alive. 
+Slackscot provides the pieces to make your mascot but you'll have to assemble them for him/her to come alive. 
 
 
-Here's an example of how Youppi does it:
+Here's an example of how [Youppi](https://github.com/alexandre-normand/youppi) does it:
 ```
 package main
 
@@ -46,9 +55,12 @@ func main() {
 		log.Fatal(err)
 	}
 
-	youppi := slackscot.NewSlackscot([]slackscot.ExtentionBundle{brain.NewKarma(), brain.NewImager()})
+	youppi := slackscot.NewSlackscot("youppi", []slackscot.Plugin{plugins.NewKarma(), plugins.NewImager(), plugins.NewFingerQuoter(), plugins.NewEmojiBannerMaker()})
 
-	slackscot.Run(*youppi, *config)
+	err = youppi.Run(*config)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 ```
 
@@ -57,8 +69,9 @@ You'll also need to define your `json` configuration for the core, built-in exte
 ```
 {
    "token": "your-slack-bot-token",
+   "debug": false,
    "storagePath": "/your-path-to-bot-home",
-   "extensions": {
+   "plugins": {
       "fingerQuoter": {
          "frequency": "100",
          "channelIds": ""

--- a/config/config.go
+++ b/config/config.go
@@ -9,8 +9,9 @@ import (
 
 type Configuration struct {
 	Token       string                       `json:"token"`
+	Debug       bool                         `json:"debug"`
 	StoragePath string                       `json:"storagePath"`
-	Extentions  map[string]map[string]string `json:"extensions"`
+	Plugins     map[string]map[string]string `json:"plugins"`
 }
 
 func LoadConfiguration(configurationPath string) (configuration *Configuration, err error) {
@@ -22,7 +23,7 @@ func LoadConfiguration(configurationPath string) (configuration *Configuration, 
 	configuration = new(Configuration)
 	err = json.Unmarshal(content, configuration)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Failed to decode configuration file [%s]: %v", configurationPath, err))
+		return nil, errors.New(fmt.Sprintf("Failed to parse configuration file [%s]: %v", configurationPath, err))
 	}
 
 	return configuration, nil

--- a/plugins/fingerquoter.go
+++ b/plugins/fingerquoter.go
@@ -1,9 +1,8 @@
-package brain
+package plugins
 
 import (
 	"errors"
 	"fmt"
-	"github.com/alexandre-normand/slack"
 	"github.com/alexandre-normand/slackscot"
 	"github.com/alexandre-normand/slackscot/config"
 	"log"
@@ -12,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 )
 
 const (
@@ -30,20 +30,20 @@ func (fingerQuoter FingerQuoter) String() string {
 	return "fingerQuoter"
 }
 
-func (fingerQuoter FingerQuoter) Init(config config.Configuration) (commands []slackscot.Action, listeners []slackscot.Action, err error) {
+func (fingerQuoter FingerQuoter) Init(config config.Configuration) (commands []slackscot.ActionDefinition, listeners []slackscot.ActionDefinition, err error) {
 	fingerQuoterRegex := regexp.MustCompile("(?i)([a-zA-Z\\-]{5,16})+")
 
 	var channels []string
 	frequency := 0
 
-	if extensionConfig, ok := config.Extentions[fingerQuoter.String()]; !ok {
+	if pluginConfig, ok := config.Plugins[fingerQuoter.String()]; !ok {
 		return nil, nil, errors.New(fmt.Sprintf("Missing extention config for %s", fingerQuoter.String()))
 	} else {
-		if channelValue, ok := extensionConfig[CHANNELS]; ok {
+		if channelValue, ok := pluginConfig[CHANNELS]; ok {
 			channels = strings.Split(channelValue, ",")
 		}
 
-		if frequencyValue, ok := extensionConfig[FREQUENCY]; !ok {
+		if frequencyValue, ok := pluginConfig[FREQUENCY]; !ok {
 			return nil, nil, errors.New(fmt.Sprintf("Missing %s config key: %s", fingerQuoter.String(), FREQUENCY))
 		} else {
 			frequency, err = strconv.Atoi(frequencyValue)
@@ -56,24 +56,27 @@ func (fingerQuoter FingerQuoter) Init(config config.Configuration) (commands []s
 	randomGen := rand.New(rand.NewSource(time.Now().UnixNano()))
 	log.Printf("%s loaded with frequency [%d] and whitelist [%s]", fingerQuoter, frequency, channels)
 
-	listeners = append(listeners, slackscot.Action{
+	listeners = append(listeners, slackscot.ActionDefinition{
 		Hidden:      true,
 		Regex:       fingerQuoterRegex,
 		Usage:       "just speak",
 		Description: "finger quoter listens to what people say and (sometimes) finger quotes a word",
-		Answerer: func(message *slack.Message) string {
-			if isChannelWhiteListed(message.ChannelId, channels) {
-				words := fingerQuoterRegex.FindAllString(message.Text, -1)
-				log.Printf("All words are: %v", words)
+		Answerer: func(me *slackscot.IncomingMessageEvent) string {
+			if isChannelWhiteListed(me.Channel, channels) {
+				words := strings.FieldsFunc(me.Text, func(c rune) bool {
+					return !unicode.IsLetter(c) && c != '-'
+				})
+
+				candidates := filterWordsLongerThan(words, 5)
 
 				// Determine if we're going to react this time or not
 				if randomGen.Int31n(int32(frequency)) == 0 {
 					// That's it, let's pick a word and finger-quote it
-					i := randomGen.Int31n(int32(len(words)))
-					return fmt.Sprintf("\"%s\"", words[i])
+					i := randomGen.Int31n(int32(len(candidates)))
+					return fmt.Sprintf("\"%s\"", candidates[i])
 				}
-			} else {
-				log.Printf("Channel [%s] is not whitelisted.", message.ChannelId)
+			} else if config.Debug {
+				log.Printf("Channel [%s] is not whitelisted.", me.Channel)
 			}
 			// Not this time, skip
 			return ""
@@ -83,8 +86,19 @@ func (fingerQuoter FingerQuoter) Init(config config.Configuration) (commands []s
 	return commands, listeners, nil
 }
 
+func filterWordsLongerThan(words []string, minLen int) []string {
+	candidates := make([]string, 0)
+	for _, w := range words {
+		if len(w) > minLen {
+			candidates = append(candidates, w)
+		}
+	}
+
+	return candidates
+}
+
 func isChannelWhiteListed(channelId string, whitelist []string) bool {
-	// Default to all channels whitelisted if none specified
+	// Default to all channels whitelisted if none specified which is either that the element is missing or if the only element is empty string
 	if len(whitelist) == 0 {
 		return true
 	}

--- a/plugins/imager.go
+++ b/plugins/imager.go
@@ -1,9 +1,8 @@
-package brain
+package plugins
 
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/alexandre-normand/slack"
 	"github.com/alexandre-normand/slackscot"
 	"github.com/alexandre-normand/slackscot/config"
 	"io/ioutil"
@@ -78,7 +77,7 @@ func (imager Imager) String() string {
 	return "imager"
 }
 
-func (imager Imager) Init(config config.Configuration) (commands []slackscot.Action, listeners []slackscot.Action, err error) {
+func (imager Imager) Init(config config.Configuration) (commands []slackscot.ActionDefinition, listeners []slackscot.ActionDefinition, err error) {
 	imageRegex := regexp.MustCompile("(?i)(image|img) (.*)")
 	animateRegex := regexp.MustCompile("(?i)(animate) (.*)")
 	moosificateRegex := regexp.MustCompile("(?i)(moosificate) (.*)")
@@ -86,20 +85,20 @@ func (imager Imager) Init(config config.Configuration) (commands []slackscot.Act
 	urlRegex := regexp.MustCompile("(?i).*https?://.*")
 	bombRegex := regexp.MustCompile("(?i)(bomb) (\\d+) (.+)")
 
-	commands = append(commands, slackscot.Action{
+	commands = append(commands, slackscot.ActionDefinition{
 		Regex:       imageRegex,
 		Usage:       "image <search expression>",
 		Description: "Queries Google Images for _search expression_ and returns random result",
-		Answerer: func(message *slack.Message) string {
+		Answerer: func(message *slackscot.IncomingMessageEvent) string {
 			return processQueryAndSearch(message.Text, imageRegex, false)
 		},
 	})
 
-	commands = append(commands, slackscot.Action{
+	commands = append(commands, slackscot.ActionDefinition{
 		Regex:       animateRegex,
 		Usage:       "animate <search expression>",
 		Description: "The sames as `image` except requests an animated gif matching _search expression_",
-		Answerer: func(message *slack.Message) string {
+		Answerer: func(message *slackscot.IncomingMessageEvent) string {
 			searchExpression := animateRegex.FindAllStringSubmatch(message.Text, -1)[0]
 			log.Printf("Matches %v", searchExpression)
 
@@ -107,11 +106,11 @@ func (imager Imager) Init(config config.Configuration) (commands []slackscot.Act
 		},
 	})
 
-	commands = append(commands, slackscot.Action{
+	commands = append(commands, slackscot.ActionDefinition{
 		Regex:       moosificateRegex,
 		Usage:       "moosificate <search expression or image url>",
 		Description: "Moosificates an image from either an image search for the _search expression_ or a direct image URL",
-		Answerer: func(message *slack.Message) string {
+		Answerer: func(message *slackscot.IncomingMessageEvent) string {
 			match := moosificateRegex.FindAllStringSubmatch(message.Text, -1)[0]
 			log.Printf("Here are the matches: [%v]", match)
 
@@ -128,11 +127,11 @@ func (imager Imager) Init(config config.Configuration) (commands []slackscot.Act
 		},
 	})
 
-	commands = append(commands, slackscot.Action{
+	commands = append(commands, slackscot.ActionDefinition{
 		Regex:       antlerificateRegex,
 		Usage:       "antlerlificate <search expression or image url>",
 		Description: "Antlerlificates an image from either an image search for the _search expression_ or a direct image URL",
-		Answerer: func(message *slack.Message) string {
+		Answerer: func(message *slackscot.IncomingMessageEvent) string {
 			match := antlerificateRegex.FindAllStringSubmatch(message.Text, -1)[0]
 			log.Printf("Here are the matches: [%v]", match)
 
@@ -149,11 +148,11 @@ func (imager Imager) Init(config config.Configuration) (commands []slackscot.Act
 		},
 	})
 
-	commands = append(commands, slackscot.Action{
+	commands = append(commands, slackscot.ActionDefinition{
 		Regex:       bombRegex,
 		Usage:       "bomb <howMany> <search expression>",
 		Description: "The `image me` except repeated multiple times",
-		Answerer: func(message *slack.Message) string {
+		Answerer: func(message *slackscot.IncomingMessageEvent) string {
 			match := bombRegex.FindAllStringSubmatch(message.Text, -1)[0]
 			log.Printf("Here are the matches: [%v], [%s] [%s]", match, match[2], match[3])
 			count, _ := strconv.Atoi(match[2])

--- a/plugins/karma.go
+++ b/plugins/karma.go
@@ -1,10 +1,9 @@
-package brain
+package plugins
 
 import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/alexandre-normand/slack"
 	"github.com/alexandre-normand/slackscot"
 	"github.com/alexandre-normand/slackscot/config"
 	"github.com/alexandre-normand/slackscot/store"
@@ -27,7 +26,7 @@ func (karma Karma) String() string {
 	return "karma"
 }
 
-func (karma Karma) Init(config config.Configuration) (commands []slackscot.Action, listeners []slackscot.Action, err error) {
+func (karma Karma) Init(config config.Configuration) (commands []slackscot.ActionDefinition, listeners []slackscot.ActionDefinition, err error) {
 	karma.karmaStore, err = store.NewStore("karma", config.StoragePath)
 	if err != nil {
 		return nil, nil, err
@@ -35,12 +34,12 @@ func (karma Karma) Init(config config.Configuration) (commands []slackscot.Actio
 
 	karmaRegex := regexp.MustCompile("\\s*(\\w+)(\\+\\+|\\-\\-).*")
 
-	listeners = append(listeners, slackscot.Action{
+	listeners = append(listeners, slackscot.ActionDefinition{
 		Hidden:      false,
 		Regex:       karmaRegex,
 		Usage:       "thing++ or thing--",
 		Description: "Keep track of karma",
-		Answerer: func(message *slack.Message) string {
+		Answerer: func(message *slackscot.IncomingMessageEvent) string {
 			match := karmaRegex.FindAllStringSubmatch(message.Text, -1)[0]
 			log.Printf("Here are the matches: [%v]", match)
 			var format string
@@ -74,12 +73,12 @@ func (karma Karma) Init(config config.Configuration) (commands []slackscot.Actio
 
 	topKarmaRegexp := regexp.MustCompile("(?i)(karma top)+ (\\d+).*")
 
-	commands = append(commands, slackscot.Action{
+	commands = append(commands, slackscot.ActionDefinition{
 		Hidden:      false,
 		Regex:       topKarmaRegexp,
 		Usage:       "karma top <howMany>",
 		Description: "Return the X top things ever",
-		Answerer: func(message *slack.Message) string {
+		Answerer: func(message *slackscot.IncomingMessageEvent) string {
 			match := topKarmaRegexp.FindAllStringSubmatch(message.Text, -1)[0]
 			log.Printf("Here are the matches: [%v]", match)
 
@@ -101,14 +100,13 @@ func (karma Karma) Init(config config.Configuration) (commands []slackscot.Actio
 	})
 
 	worstKarmaRegexp := regexp.MustCompile("(?i)(karma worst)+ (\\d+).*")
-	commands = append(commands, slackscot.Action{
+	commands = append(commands, slackscot.ActionDefinition{
 		Hidden:      false,
 		Regex:       worstKarmaRegexp,
 		Usage:       "karma worst <howMany>",
 		Description: "Return the X worst things ever",
-		Answerer: func(message *slack.Message) string {
+		Answerer: func(message *slackscot.IncomingMessageEvent) string {
 			match := worstKarmaRegexp.FindAllStringSubmatch(message.Text, -1)[0]
-			log.Printf("Here are the matches: [%v]", match)
 
 			rawCount := match[2]
 			count, _ := strconv.Atoi(rawCount)

--- a/slackscot.go
+++ b/slackscot.go
@@ -2,117 +2,133 @@ package slackscot
 
 import (
 	"fmt"
-	"github.com/alexandre-normand/slack"
 	"github.com/alexandre-normand/slackscot/config"
+	"github.com/nlopes/slack"
 	"log"
+	"os"
 	"regexp"
 )
 
-type Action struct {
-	// indicates whether the action should be omitted from the bot's help message.
-	// Defaults to false.
-	Hidden bool
-
-	// pattern to match in the message for the action's Answerer function to execute
-	Regex *regexp.Regexp
-
-	// usage example
-	Usage string
-
-	// textual help description for the action
-	Description string
-
-	// function to execute if the Regex matches
-	Answerer ActionFunc
-}
-
-func (a Action) String() string {
-	return fmt.Sprintf("`%s` - %s", a.Usage, a.Description)
-}
-
-type ActionFunc func(*slack.Message) string
-
+// Slackscot represents what defines a Slack Mascot (mostly, a name and its plugins)
 type Slackscot struct {
-	bundles []ExtentionBundle
+	name    string
+	plugins []Plugin
+	botEngine
 }
 
-type ExtentionBundle interface {
+// Plugin defines the lifecycle functions of a plugin: Init and Close
+type Plugin interface {
 	fmt.Stringer
-	Init(config.Configuration) (commands []Action, listeners []Action, err error)
+	Init(config.Configuration) (commands []ActionDefinition, listeners []ActionDefinition, err error)
 	Close()
 }
 
-var tellCommand = regexp.MustCompile("(?i)tell (<.*?>)( .*)? <#(.*?)>? (.*)")
+// ActionDefinition represents how an action is triggered, published, used and described
+// along with defining the function defining its behavior
+type ActionDefinition struct {
+	// Indicates whether the action should be omitted from the help message
+	Hidden bool
 
-var defaultAction ActionFunc
+	// Pattern to match in the message for the action's Answerer function to execute
+	Regex *regexp.Regexp
 
-var hearActions actionList
-var commands actionList
+	// Usage example
+	Usage string
 
-type actionList []Action
+	// Help description for the action
+	Description string
 
-func NewSlackscot(bundles []ExtentionBundle) (bot *Slackscot) {
-	return &Slackscot{bundles: bundles}
+	// Function to execute if the Regex matches
+	Answerer ActionFunc
 }
 
-func (a actionList) handle(message *slack.Message, command bool) bool {
-	handled := false
+// String returns a friendly description of an ActionDefinition
+func (a ActionDefinition) String() string {
+	return fmt.Sprintf("`%s` - %s", a.Usage, a.Description)
+}
 
-	var action Action
-	for _, action = range a {
-		matches := action.Regex.FindStringSubmatch(message.Text)
+// ActionFunc is what gets executed when an ActionDefinition is triggered
+type ActionFunc func(ime *IncomingMessageEvent) string
 
-		if len(matches) > 0 {
-			response := action.Answerer(message)
+// responseStrategy defines how a slack.OutgoingMessage is generated from a response
+type responseStrategy func(rtm *slack.RTM, ime *IncomingMessageEvent, response string) *slack.OutgoingMessage
 
-			if response != "" {
-				handled = true
-				log.Printf("me-> %s", response)
-				if command {
-					if err := message.Respond(response); err != nil {
-						// gulp!
-						log.Printf("Error responding to message: %s\nwith Message: '%s'", err, response)
-					}
-				} else {
-					if err := message.Send(response); err != nil {
-						// gulp!
-						log.Printf("Error responding to message: %s\nwith Message: '%s'", err, response)
-					}
-				}
+// botEngine is the internal representation of a running bot
+type botEngine struct {
+	defaultAction ActionFunc
+	hearActions   []ActionDefinition
+	commands      []ActionDefinition
+}
 
+// IncomingMessageEvent embeds a slack MessageEvent and adds a few internal slackscot bits of context
+// Namely: the existingReplyMsgId which is set by slackscot if a modified or deleted message is seen to which
+// he/she had replied to already. This can be used to modify/delete that response message instead of ignoring it or
+// responding with a new message.
+type IncomingMessageEvent struct {
+	slack.MessageEvent
+	// TODO: fill this in when receiving a new message event so that handling can then use it to update the existing message
+	// or delete it
+	existingReplyMsgId SlackMsgId
+}
+
+// SlackMsgId holds the elements that form a unique message identifier for slack. Technically, slack also uses
+// the workspace id as the first part of that unique identifier but since an instance of slackscot only lives within
+// a single workspace, that part is left out
+type SlackMsgId struct {
+	channelId string
+	timestamp int
+}
+
+// NewSlackscot creates a new slackscot from an array of plugins and a name
+func NewSlackscot(name string, plugins []Plugin) (bot *Slackscot) {
+	return &Slackscot{name: name, plugins: plugins}
+}
+
+// init initializes all plugins and creates the internal botEngine to start processing messages
+func (s *Slackscot) init(config config.Configuration) error {
+	commands := make([]ActionDefinition, 0)
+	hearActions := make([]ActionDefinition, 0)
+
+	// Keep track of initialized plugins in case one fails to initialize and we need to close the ones
+	// already initialized before returning
+	initializedPlugins := make([]Plugin, 0)
+	for _, p := range s.plugins {
+		c, h, err := p.Init(config)
+		if err != nil {
+			// Close all plugins already initialized already before returning error and shutting down everything
+			for _, ip := range initializedPlugins {
+				ip.Close()
 			}
+
+			return err
 		}
+
+		initializedPlugins = append(initializedPlugins, p)
+		commands = append(commands, c...)
+		hearActions = append(hearActions, h...)
 	}
 
-	return handled
+	helpCommand := generateHelpCommand(s.name, commands, hearActions)
+	allCommands := append(commands, helpCommand)
+
+	// Set internal state representing the bot's engine
+	s.botEngine = botEngine{defaultAction: func(ime *IncomingMessageEvent) string {
+		return fmt.Sprintf("I don't understand, ask me for \"%s\" to get a list of things I do", helpCommand.Usage)
+	}, hearActions: hearActions, commands: allCommands}
+
+	return nil
 }
 
-func registerCommand(newAction Action) {
-	log.Printf("\nRegistering command: %s", newAction)
-	commands = append(commands, newAction)
-}
-
-func registerAction(newAction Action) {
-	log.Printf("\nRegistering Action: %s", newAction)
-	hearActions = append(hearActions, newAction)
-}
-
-func registerDefault(action ActionFunc) {
-	log.Printf("\nRegistering Default Action: %#v", action)
-	if defaultAction != nil {
-		panic(fmt.Sprintf("Attempted to set default action failed because one has already been registered: %#v", defaultAction))
-	}
-	defaultAction = action
-}
-
-func init() {
-	registerCommand(Action{
+// generateHelpCommand generates a command providing a list of all of the slackscot commands and hear actions.
+// Note that ActionDefinitions with the flag Hidden set to true won't be included in the list
+func generateHelpCommand(name string, commands []ActionDefinition, hearActions []ActionDefinition) ActionDefinition {
+	return ActionDefinition{
 		Regex:       regexp.MustCompile("(?i)help"),
 		Usage:       "help",
 		Description: "Reply with usage instructions",
-		Answerer: func(dummy *slack.Message) string {
-			response := "I am a robot that listens to the team's chat and provides automated functions." +
-				"  I currently support the following commands:\n"
+		Answerer: func(ime *IncomingMessageEvent) string {
+			response := fmt.Sprintf("I'm `%s` (engine version `%s`) that listens to the team's chat and provides automated functions."+
+				"  I currently support the following commands:\n", name, VERSION)
 
 			for _, value := range commands {
 				if value.Usage != "" && !value.Hidden {
@@ -126,83 +142,179 @@ func init() {
 				}
 			}
 
-			return response + "\n\nI can do some other things too - try asking me something!"
+			return response
 		},
-	})
-}
-
-func onHeardMessage(message *slack.Message) {
-	hearActions.handle(message, false)
-}
-
-func onAskedMessage(message *slack.Message) {
-	log.Printf("%s-> %s", message.From, message.Text)
-
-	matches := tellCommand.FindStringSubmatch(message.Text)
-	if len(matches) > 0 {
-		message.Tell(matches[3], matches[1]+": "+matches[4])
-		return
-	}
-
-	handled := commands.handle(message, true)
-
-	if !handled {
-		var response string
-
-		if defaultAction != nil {
-			// if sentence not matched to a supported request then fallback to a default
-			response = defaultAction(message)
-		} else {
-			response = "Je comprends pas.\n_Dis-moi_ `help` _pour avoir la liste des commandes_"
-		}
-
-		log.Printf("me-> %s", response)
-		if err := message.Respond(response); err != nil {
-			// gulp!
-			log.Printf("Error responding to message: %s\nwith Message: '%s'", err, response)
-		}
 	}
 }
 
-func Run(slackscot Slackscot, config config.Configuration) (err error) {
-	conn, err := slack.Connect(config.Token)
+// Close closes slackscot (its plugins) gracefully
+func (s *Slackscot) Close() {
+	for _, p := range s.plugins {
+		p.Close()
+	}
+}
+
+// Run starts the Slackscot and loops until the process is interrupted
+func (s *Slackscot) Run(config config.Configuration) (err error) {
+	api := slack.New(
+		config.Token,
+		slack.OptionDebug(config.Debug),
+		slack.OptionLog(log.New(os.Stdout, "slackscot: ", log.Lshortfile|log.LstdFlags)),
+	)
+
+	rtm := api.NewRTM()
+	go rtm.ManageConnection()
+
+	// Initialize slackscot (and all its plugins)
+	err = s.init(config)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
-	// Register all commands and listeners
+	// Register the close of slackscot when the process terminates
+	defer s.Close()
 
-	var commands []Action
-	var listeners []Action
+	for msg := range rtm.IncomingEvents {
+		switch e := msg.Data.(type) {
+		case *slack.HelloEvent:
+			// Ignore hello
 
-	for _, b := range slackscot.bundles {
-		c, l, err := b.Init(config)
-		if err != nil {
-			return err
+		case *slack.ConnectedEvent:
+			log.Println("Infos:", e.Info)
+			log.Println("Connection counter:", e.ConnectionCount)
+
+		case *slack.MessageEvent:
+			s.processMessageEvent(rtm, e)
+
+		case *slack.PresenceChangeEvent:
+			log.Printf("Presence Change: %v\n", e)
+
+		case *slack.LatencyReport:
+			log.Printf("Current latency: %v\n", e.Value)
+
+		case *slack.RTMError:
+			log.Printf("Error: %s\n", e.Error())
+
+		case *slack.InvalidAuthEvent:
+			log.Printf("Invalid credentials")
+			return
+
+		default:
+			// Ignore other events
 		}
-
-		commands = append(commands, c...)
-		listeners = append(listeners, l...)
 	}
-
-	// Register the close of resources when the process terminates
-	defer Close(slackscot)
-
-	for _, c := range commands {
-		registerCommand(c)
-	}
-
-	for _, l := range listeners {
-		registerAction(l)
-	}
-
-	slack.EventProcessor(conn, onAskedMessage, onHeardMessage)
 
 	return nil
 }
 
-func Close(slackscot Slackscot) {
-	for _, b := range slackscot.bundles {
-		b.Close()
+// processMessageEvent handles high-level processing of all slack message events.
+//
+// TODO (coming soon):
+// In the case of updated messages or deleted messages,
+// slackscot will look for an existing reply to that message. In the case of a deleted message that triggered a response from the bot,
+// that message will be deleted from slack. For a changed message, slackscot will either delete the message if not handled anymore or
+// will update the original response if it is still handled
+func (b *botEngine) processMessageEvent(c *slack.RTM, msgEvent *slack.MessageEvent) {
+	// reply_to is an field set to 1 sent by slack when a sent message has been acknowledged and should be considered
+	// officially sent to others. Therefore, we ignore all of those since it's mostly for clients/UI to show status
+	isReply := msgEvent.ReplyTo > 0
+
+	// TODO retrieve stored reply (if any) and change reaction (if appropriate)
+	subtype := msgEvent.SubType
+	isMessageChangedEvent := subtype == "message_changed" || subtype == "message_deleted"
+
+	ime := &IncomingMessageEvent{MessageEvent: *msgEvent}
+	if !isReply && !isMessageChangedEvent {
+		if msgEvent.Type == "message" {
+			b.routeMessage(c, ime)
+		} else {
+			log.Printf("message type is %v", msgEvent.Type)
+		}
 	}
+}
+
+// routeMessage handles routing the message to commands or hear actions according to the context
+// The rules are the following:
+// 	1. If the message is on a channel with a direct mention to us (@name), we route to commands
+// 	2. If the message is a direct message to us, we route to commands
+// 	3. If the message is on a channel without mention (regular conversation), we route to hear actions
+func (b *botEngine) routeMessage(rtm *slack.RTM, ime *IncomingMessageEvent) {
+	selfId := rtm.GetInfo().User.ID
+	selfName := rtm.GetInfo().User.Name
+
+	// Built regex to detect if message was directed at "us"
+	r, _ := regexp.Compile("^(<@" + selfId + ">|@?" + selfName + "):? (.+)")
+
+	matches := r.FindStringSubmatch(ime.Text)
+
+	if len(matches) == 3 {
+		if b.commands != nil {
+			handleCommand(b.defaultAction, b.commands, rtm, matches[2], ime, reply)
+		}
+	} else if ime.Channel[0] == 'D' {
+		if b.commands != nil {
+			handleCommand(b.defaultAction, b.commands, rtm, ime.Text, ime, directReply)
+		}
+	} else {
+		if b.hearActions != nil {
+			handleMessage(b.hearActions, rtm, ime.Text, ime, send)
+		}
+	}
+}
+
+// handleCommand handles a command by trying a match with all known actions. If no match is found, the default action is invoked
+// Note that in the case of the default action being executed, the return value is still false to indicate no bot actions were triggered
+func handleCommand(defaultAction ActionFunc, actions []ActionDefinition, rtm *slack.RTM, content string, ime *IncomingMessageEvent, rs responseStrategy) bool {
+	handled := handleMessage(actions, rtm, content, ime, rs)
+	if !handled {
+		response := defaultAction(ime)
+
+		outMsg := rs(rtm, ime, response)
+		rtm.SendMessage(outMsg)
+	}
+
+	return handled
+}
+
+// processMessage loops over all action definitions and invokes its action if the incoming message matches it's regular expression
+// Note that more than one action can be triggered during the processing of a single message
+func handleMessage(actions []ActionDefinition, rtm *slack.RTM, content string, ime *IncomingMessageEvent, rs responseStrategy) bool {
+	handled := false
+
+	var action ActionDefinition
+	for _, action = range actions {
+		matches := action.Regex.FindStringSubmatch(ime.Text)
+
+		if len(matches) > 0 {
+			response := action.Answerer(ime)
+
+			if response != "" {
+				handled = true
+
+				outMsg := rs(rtm, ime, response)
+				rtm.SendMessage(outMsg)
+			}
+		}
+	}
+
+	return handled
+}
+
+// reply sends a reply to the user (using @user) who sent the message on the channel it was sent on
+func reply(rtm *slack.RTM, ime *IncomingMessageEvent, response string) *slack.OutgoingMessage {
+	om := rtm.NewOutgoingMessage(fmt.Sprintf("<@%s>: %s", ime.User, response), ime.Channel)
+	return om
+}
+
+// directReply sends a reply to a direct message (which is internally a channel id for slack). It is essentially
+// the same as send but it's kept separate for clarity
+func directReply(rtm *slack.RTM, ime *IncomingMessageEvent, response string) *slack.OutgoingMessage {
+	return send(rtm, ime, response)
+}
+
+// send creates a message to be sent on the same channel as received (which can be a direct message since
+// slack internally uses a channel id for private conversations)
+func send(rtm *slack.RTM, ime *IncomingMessageEvent, response string) *slack.OutgoingMessage {
+	om := rtm.NewOutgoingMessage(response, ime.Channel)
+	return om
 }

--- a/version.go
+++ b/version.go
@@ -1,0 +1,6 @@
+// GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
+package slackscot
+
+const (
+	VERSION = "1.0.0"
+)


### PR DESCRIPTION
@s-machina: I thought maybe you'd enjoy reviewing this. I started out wanting to update `slackscot` to a `go` `slack API` integration that was still actively maintained and it looks like https://www.github.com/nlopes/slack is exactly that. But I also wanted to make things a little cleaner and remove some of the extra cruft that I had added in a haste when I was trying to get `youppi` out during the course of only a few days. It's now cleaner even though I'd like to revisit some patterns later on (I've been debating wether or not to use plain functions vs functions with structs as receivers in a few places). 

I think this is mostly the start of something nice. In my short-term todo, I have:
- I'd like to handle triggering messages that get updated as well as updated messages that should now be reevaluated for a match (previously, the api I was using was just ignoring updated/deleted messages). 
- I think I'd also like to cache user emails/full names and make those available in the `IncomingMessageEvent` so that plugins have access to them (emails can be useful for functionality while names/first names can be useful to include in a formatted response). 
- Matching that isn't based purely on regex. I'll probably have something a bit more generic that could trigger a match based on probability match (useful for the `fingerquoting` so that this doesn't have to be done during main processing) along with a wrapper that takes in a regex and checks for a match. 
- Maybe support for `vault` in configuration evaluation where we could have `vault` paths in value and if a `vault host` and `vault token` are presents then those values would be fetched from `vault` before initialization. 

It looks like `GitHub` hides `slackscot.go` by default but that's actually where the most interesting changes are. 

Otherwise, he's a potentially incomplete list of changes:

- Add home directory expansion on emojiBanner's fontPath
- Add Slackscot engine version in help message output
- Integrate with https://github.com/alexandre-normand/giddyup for version management (will integrate auto-releases
  on merge later)
- Major refactor and code clean up
- Prepare terrain for response updating/deletion on triggering message updates
- Add more godoc
- Update README and add go report card icon