### PR TITLE
Remove Redundant Schedule in schedule.ScheduleDefinition

### DIFF
--- a/help.go
+++ b/help.go
@@ -93,7 +93,7 @@ func (h *helpPlugin) showHelp(m *slack.Msg) string {
 
 		for _, value := range h.pluginScheduledActions {
 			if !value.ScheduledActionDefinition.Hidden {
-				fmt.Fprintf(&b, "\t• [`%s`] `%s` (`%s`) - %s\n", value.plugin, value.ScheduledActionDefinition.ScheduleDefinition, h.v.GetString(config.TimeLocationKey), value.ScheduledActionDefinition.Description)
+				fmt.Fprintf(&b, "\t• [`%s`] `%s` (`%s`) - %s\n", value.plugin, value.ScheduledActionDefinition.Schedule, h.v.GetString(config.TimeLocationKey), value.ScheduledActionDefinition.Description)
 			}
 		}
 	}

--- a/plugins/ohmonday.go
+++ b/plugins/ohmonday.go
@@ -50,7 +50,7 @@ type OhMonday struct {
 func NewOhMonday(c *config.PluginConfig) (o *OhMonday, err error) {
 	c.SetDefault(atTimeKey, defaultAtTime)
 
-	scheduleDefinition := schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Weeks, Weekday: time.Monday.String(), AtTime: c.GetString(atTimeKey)}
+	scheduleDefinition := schedule.Definition{Interval: 1, Unit: schedule.Weeks, Weekday: time.Monday.String(), AtTime: c.GetString(atTimeKey)}
 
 	if ok := c.IsSet(channelIdKey); !ok {
 		return nil, fmt.Errorf("Missing [%s] configuration key for plugin [%s]", channelIdKey, OhMondayPluginName)
@@ -59,7 +59,7 @@ func NewOhMonday(c *config.PluginConfig) (o *OhMonday, err error) {
 	o = new(OhMonday)
 	o.Name = OhMondayPluginName
 	o.channelId = c.GetString(channelIdKey)
-	o.ScheduledActions = []slackscot.ScheduledActionDefinition{{ScheduleDefinition: scheduleDefinition, Description: "Start the week off with a nice greeting", Action: o.sendGreeting}}
+	o.ScheduledActions = []slackscot.ScheduledActionDefinition{{Schedule: scheduleDefinition, Description: "Start the week off with a nice greeting", Action: o.sendGreeting}}
 
 	return o, nil
 }

--- a/plugins/ohmonday_test.go
+++ b/plugins/ohmonday_test.go
@@ -58,7 +58,7 @@ func TestDefaultAtTime(t *testing.T) {
 	assert.Nil(t, err)
 	sa := o.ScheduledActions[0]
 
-	assert.Equal(t, schedule.ScheduleDefinition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "10:00"}, sa.ScheduleDefinition)
+	assert.Equal(t, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "10:00"}, sa.Schedule)
 }
 
 func TestMissingChannelId(t *testing.T) {
@@ -79,6 +79,6 @@ func TestAtTimeOverride(t *testing.T) {
 	assert.Nil(t, err)
 	sa := o.ScheduledActions[0]
 
-	assert.Equal(t, schedule.ScheduleDefinition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "11:00"}, sa.ScheduleDefinition)
+	assert.Equal(t, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "11:00"}, sa.Schedule)
 
 }

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -8,8 +8,8 @@ import (
 	"time"
 )
 
-// ScheduleDefinition repesents
-type ScheduleDefinition struct {
+// Definition holds the data defining a schedule definition
+type Definition struct {
 	// Internal value (every 1 minute would be expressed with an interval of 1). Must be set explicitly or implicitly (a weekday value implicitly sets the interval to 1)
 	Interval uint64
 
@@ -42,22 +42,22 @@ var weekdayToNumeral = map[string]time.Weekday{
 	time.Sunday.String():    time.Sunday,
 }
 
-// Returns a human-friendly string for the ScheduledDefinition
-func (s ScheduleDefinition) String() string {
+// Returns a human-friendly string for the schedule definition
+func (d Definition) String() string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "Every ")
 
-	if s.Weekday != "" {
-		fmt.Fprintf(&b, "%s", s.Weekday)
-	} else if s.Interval == 1 {
-		fmt.Fprintf(&b, "%s", strings.TrimSuffix(s.Unit, "s"))
+	if d.Weekday != "" {
+		fmt.Fprintf(&b, "%s", d.Weekday)
+	} else if d.Interval == 1 {
+		fmt.Fprintf(&b, "%s", strings.TrimSuffix(d.Unit, "s"))
 	} else {
-		fmt.Fprintf(&b, "%d %s", s.Interval, s.Unit)
+		fmt.Fprintf(&b, "%d %s", d.Interval, d.Unit)
 	}
 
-	if s.AtTime != "" {
-		fmt.Fprintf(&b, " at %s", s.AtTime)
+	if d.AtTime != "" {
+		fmt.Fprintf(&b, " at %s", d.AtTime)
 	}
 
 	return b.String()
@@ -114,19 +114,19 @@ func optionAtTime(atTime string) func(j *gocron.Job) {
 }
 
 // NewJob sets up the gocron.Job with the schedule and leaves the task undefined for the caller to set up
-func NewJob(s *gocron.Scheduler, sd ScheduleDefinition) (j *gocron.Job, err error) {
-	j = s.Every(sd.Interval, false)
+func NewJob(s *gocron.Scheduler, def Definition) (j *gocron.Job, err error) {
+	j = s.Every(def.Interval, false)
 
 	scheduleOptions := make([]scheduleOption, 0)
 
-	if sd.Weekday != "" {
-		scheduleOptions = append(scheduleOptions, optionWeekday(sd.Weekday))
-	} else if sd.Unit != "" {
-		scheduleOptions = append(scheduleOptions, optionUnit(sd.Unit))
+	if def.Weekday != "" {
+		scheduleOptions = append(scheduleOptions, optionWeekday(def.Weekday))
+	} else if def.Unit != "" {
+		scheduleOptions = append(scheduleOptions, optionUnit(def.Unit))
 	}
 
-	if sd.AtTime != "" {
-		scheduleOptions = append(scheduleOptions, optionAtTime(sd.AtTime))
+	if def.AtTime != "" {
+		scheduleOptions = append(scheduleOptions, optionAtTime(def.AtTime))
 	}
 
 	for _, option := range scheduleOptions {

--- a/schedule/schedule_test.go
+++ b/schedule/schedule_test.go
@@ -10,28 +10,28 @@ import (
 
 func TestScheduleDefinitionString(t *testing.T) {
 	scheduleDefinitionToString := []struct {
-		sd             schedule.ScheduleDefinition
+		sd             schedule.Definition
 		friendlyString string
 	}{
-		{schedule.ScheduleDefinition{Interval: 1, Weekday: time.Monday.String(), AtTime: "10:00"}, "Every Monday at 10:00"},
-		{schedule.ScheduleDefinition{Interval: 1, Weekday: time.Tuesday.String(), AtTime: "09:00"}, "Every Tuesday at 09:00"},
-		{schedule.ScheduleDefinition{Interval: 1, Weekday: time.Wednesday.String(), AtTime: "08:00"}, "Every Wednesday at 08:00"},
-		{schedule.ScheduleDefinition{Interval: 1, Weekday: time.Thursday.String(), AtTime: "07:00"}, "Every Thursday at 07:00"},
-		{schedule.ScheduleDefinition{Interval: 1, Weekday: time.Friday.String(), AtTime: "06:00"}, "Every Friday at 06:00"},
-		{schedule.ScheduleDefinition{Interval: 1, Weekday: time.Saturday.String(), AtTime: "05:00"}, "Every Saturday at 05:00"},
-		{schedule.ScheduleDefinition{Interval: 1, Weekday: time.Sunday.String(), AtTime: "04:00"}, "Every Sunday at 04:00"},
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Seconds}, "Every second"},
-		{schedule.ScheduleDefinition{Interval: 2, Unit: schedule.Seconds}, "Every 2 seconds"},
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Minutes}, "Every minute"},
-		{schedule.ScheduleDefinition{Interval: 2, Unit: schedule.Minutes}, "Every 2 minutes"},
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Hours}, "Every hour"},
-		{schedule.ScheduleDefinition{Interval: 2, Unit: schedule.Hours}, "Every 2 hours"},
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Days}, "Every day"},
-		{schedule.ScheduleDefinition{Interval: 2, Unit: schedule.Days}, "Every 2 days"},
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Days, AtTime: "10:00"}, "Every day at 10:00"},
-		{schedule.ScheduleDefinition{Interval: 2, Unit: schedule.Days, AtTime: "10:00"}, "Every 2 days at 10:00"},
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Weeks}, "Every week"},
-		{schedule.ScheduleDefinition{Interval: 2, Unit: schedule.Weeks}, "Every 2 weeks"},
+		{schedule.Definition{Interval: 1, Weekday: time.Monday.String(), AtTime: "10:00"}, "Every Monday at 10:00"},
+		{schedule.Definition{Interval: 1, Weekday: time.Tuesday.String(), AtTime: "09:00"}, "Every Tuesday at 09:00"},
+		{schedule.Definition{Interval: 1, Weekday: time.Wednesday.String(), AtTime: "08:00"}, "Every Wednesday at 08:00"},
+		{schedule.Definition{Interval: 1, Weekday: time.Thursday.String(), AtTime: "07:00"}, "Every Thursday at 07:00"},
+		{schedule.Definition{Interval: 1, Weekday: time.Friday.String(), AtTime: "06:00"}, "Every Friday at 06:00"},
+		{schedule.Definition{Interval: 1, Weekday: time.Saturday.String(), AtTime: "05:00"}, "Every Saturday at 05:00"},
+		{schedule.Definition{Interval: 1, Weekday: time.Sunday.String(), AtTime: "04:00"}, "Every Sunday at 04:00"},
+		{schedule.Definition{Interval: 1, Unit: schedule.Seconds}, "Every second"},
+		{schedule.Definition{Interval: 2, Unit: schedule.Seconds}, "Every 2 seconds"},
+		{schedule.Definition{Interval: 1, Unit: schedule.Minutes}, "Every minute"},
+		{schedule.Definition{Interval: 2, Unit: schedule.Minutes}, "Every 2 minutes"},
+		{schedule.Definition{Interval: 1, Unit: schedule.Hours}, "Every hour"},
+		{schedule.Definition{Interval: 2, Unit: schedule.Hours}, "Every 2 hours"},
+		{schedule.Definition{Interval: 1, Unit: schedule.Days}, "Every day"},
+		{schedule.Definition{Interval: 2, Unit: schedule.Days}, "Every 2 days"},
+		{schedule.Definition{Interval: 1, Unit: schedule.Days, AtTime: "10:00"}, "Every day at 10:00"},
+		{schedule.Definition{Interval: 2, Unit: schedule.Days, AtTime: "10:00"}, "Every 2 days at 10:00"},
+		{schedule.Definition{Interval: 1, Unit: schedule.Weeks}, "Every week"},
+		{schedule.Definition{Interval: 2, Unit: schedule.Weeks}, "Every 2 weeks"},
 	}
 
 	for _, testCase := range scheduleDefinitionToString {
@@ -44,33 +44,33 @@ func TestScheduleDefinitionString(t *testing.T) {
 
 func TestNewScheduledJobFromScheduleDefinition(t *testing.T) {
 	scheduleDefinitionToResult := []struct {
-		sd           schedule.ScheduleDefinition
+		sd           schedule.Definition
 		valid        bool
 		errorMessage string
 	}{
-		{schedule.ScheduleDefinition{Interval: 1, Weekday: time.Monday.String(), AtTime: "10:00"}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 1, Weekday: time.Tuesday.String(), AtTime: "09:00"}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 1, Weekday: time.Wednesday.String(), AtTime: "08:00"}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 1, Weekday: time.Thursday.String(), AtTime: "07:00"}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 1, Weekday: time.Friday.String(), AtTime: "06:00"}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 1, Weekday: time.Saturday.String(), AtTime: "05:00"}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 1, Weekday: time.Sunday.String(), AtTime: "04:00"}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Seconds}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 2, Unit: schedule.Seconds}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Minutes}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 2, Unit: schedule.Minutes}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Hours}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 2, Unit: schedule.Hours}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Days}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 2, Unit: schedule.Days}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Days, AtTime: "10:00"}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 2, Unit: schedule.Days, AtTime: "10:00"}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Weeks}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 2, Unit: schedule.Weeks}, true, ""},
-		{schedule.ScheduleDefinition{Interval: 2, Unit: schedule.Weeks, Weekday: time.Monday.String()}, true, ""}, // When we have a weekday, we ignore units so it's still valid
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Seconds, AtTime: "10:00"}, true, ""},             // gocron just ignores AtTime when not relevant to the unit
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Minutes, AtTime: "10:00"}, true, ""},             // gocron just ignores AtTime when not relevant to the unit
-		{schedule.ScheduleDefinition{Interval: 1, Unit: schedule.Hours, AtTime: "10:00"}, true, ""},               // gocron just ignores AtTime when not relevant to the unit
+		{schedule.Definition{Interval: 1, Weekday: time.Monday.String(), AtTime: "10:00"}, true, ""},
+		{schedule.Definition{Interval: 1, Weekday: time.Tuesday.String(), AtTime: "09:00"}, true, ""},
+		{schedule.Definition{Interval: 1, Weekday: time.Wednesday.String(), AtTime: "08:00"}, true, ""},
+		{schedule.Definition{Interval: 1, Weekday: time.Thursday.String(), AtTime: "07:00"}, true, ""},
+		{schedule.Definition{Interval: 1, Weekday: time.Friday.String(), AtTime: "06:00"}, true, ""},
+		{schedule.Definition{Interval: 1, Weekday: time.Saturday.String(), AtTime: "05:00"}, true, ""},
+		{schedule.Definition{Interval: 1, Weekday: time.Sunday.String(), AtTime: "04:00"}, true, ""},
+		{schedule.Definition{Interval: 1, Unit: schedule.Seconds}, true, ""},
+		{schedule.Definition{Interval: 2, Unit: schedule.Seconds}, true, ""},
+		{schedule.Definition{Interval: 1, Unit: schedule.Minutes}, true, ""},
+		{schedule.Definition{Interval: 2, Unit: schedule.Minutes}, true, ""},
+		{schedule.Definition{Interval: 1, Unit: schedule.Hours}, true, ""},
+		{schedule.Definition{Interval: 2, Unit: schedule.Hours}, true, ""},
+		{schedule.Definition{Interval: 1, Unit: schedule.Days}, true, ""},
+		{schedule.Definition{Interval: 2, Unit: schedule.Days}, true, ""},
+		{schedule.Definition{Interval: 1, Unit: schedule.Days, AtTime: "10:00"}, true, ""},
+		{schedule.Definition{Interval: 2, Unit: schedule.Days, AtTime: "10:00"}, true, ""},
+		{schedule.Definition{Interval: 1, Unit: schedule.Weeks}, true, ""},
+		{schedule.Definition{Interval: 2, Unit: schedule.Weeks}, true, ""},
+		{schedule.Definition{Interval: 2, Unit: schedule.Weeks, Weekday: time.Monday.String()}, true, ""}, // When we have a weekday, we ignore units so it's still valid
+		{schedule.Definition{Interval: 1, Unit: schedule.Seconds, AtTime: "10:00"}, true, ""},             // gocron just ignores AtTime when not relevant to the unit
+		{schedule.Definition{Interval: 1, Unit: schedule.Minutes, AtTime: "10:00"}, true, ""},             // gocron just ignores AtTime when not relevant to the unit
+		{schedule.Definition{Interval: 1, Unit: schedule.Hours, AtTime: "10:00"}, true, ""},               // gocron just ignores AtTime when not relevant to the unit
 	}
 
 	scheduler := gocron.NewScheduler()

--- a/slackscot.go
+++ b/slackscot.go
@@ -87,7 +87,8 @@ type ScheduledActionDefinition struct {
 	// Indicates whether the action should be omitted from the help message
 	Hidden bool
 
-	schedule.ScheduleDefinition
+	// Schedule definition determining when the action runs
+	Schedule schedule.Definition
 
 	// Help description for the scheduled action
 	Description string
@@ -104,7 +105,7 @@ type ActionDefinitionWithId struct {
 
 // String returns a friendly description of a ScheduledActionDefinition
 func (a ScheduledActionDefinition) String() string {
-	return fmt.Sprintf("`%s` - %s", a.ScheduleDefinition, a.Description)
+	return fmt.Sprintf("`%s` - %s", a.Schedule, a.Description)
 }
 
 // String returns a friendly description of an ActionDefinition
@@ -332,7 +333,7 @@ func (s *Slackscot) startActionScheduler(timeLoc *time.Location, sender RealTime
 	for _, p := range s.plugins {
 		if p.ScheduledActions != nil {
 			for _, sa := range p.ScheduledActions {
-				j, err := schedule.NewJob(sc, sa.ScheduleDefinition)
+				j, err := schedule.NewJob(sc, sa.Schedule)
 				if err != nil {
 					s.log.Debugf("Adding job [%v] to scheduler\n", j)
 					j.Do(sa.Action, sender)


### PR DESCRIPTION
## What is this about
Improving code quality metrics 

Description of the changes
Remove redundant `Schedule` in `schedule.ScheduleDefinition`

### Checklist
* [x] I've reviewed my own code
* [x] I've executed `go build ./...` and confirmed the build passes
* [x] I've run `go test ./...` and confirmed the tests pass

### Questions or relevant discussion points regarding this implementation
None