### PR TITLE
Upgrade to nlopes slack 0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - GO111MODULE=on
 
 install:
-  - mkdir -p $GOPATH/src/github.com/codeclimate && cd $GOPATH/src/github.com/codeclimate && git clone https://github.com/codeclimate/test-reporter.git && cd $GOPATH/src/github.com/codeclimate/test-reporter && go install && cd ${TRAVIS_HOME}/gopath/src/github.com/alexandre-normand/slackscot
+  - GO111MODULE=off go get github.com/codeclimate/test-reporter
 
 before_script:
   - test-reporter before-build

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/mitchellh/go-homedir v1.0.0
-	github.com/nlopes/slack v0.4.1-0.20190107041900-5911c620bb31
+	github.com/nlopes/slack v0.5.0
 	github.com/onsi/ginkgo v1.7.0 // indirect
 	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/nlopes/slack v0.4.1-0.20190107041900-5911c620bb31 h1:GLJLerZoA/XLdVS5CdfNXh5H/Bnt6XoqvfHW2IhJPLo=
 github.com/nlopes/slack v0.4.1-0.20190107041900-5911c620bb31/go.mod h1:jVI4BBK3lSktibKahxBF74txcK2vyvkza1z/+rRnVAM=
+github.com/nlopes/slack v0.5.0 h1:NbIae8Kd0NpqaEI3iUrsuS0KbcEDhzhc939jLW5fNm0=
+github.com/nlopes/slack v0.5.0/go.mod h1:jVI4BBK3lSktibKahxBF74txcK2vyvkza1z/+rRnVAM=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
## What is this about
* Upgrade to official tag of `nlopes/slack` (`0.5.0`).
* Remove scripting gymnastics to install `test-reporter` in `.travis.yml`.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass