### PR TITLE
Add Wrong Usage Test for Emoji Banner Maker Plugin

### DIFF
--- a/plugins/emojibanner.go
+++ b/plugins/emojibanner.go
@@ -115,11 +115,9 @@ func validateAndRenderEmoji(message string, regex *regexp.Regexp, renderer *figl
 	if len(commandParameters) > 0 {
 		parameters := strings.Split(commandParameters[2], " ")
 
-		if len(parameters) != 2 {
-			return "Wrong usage: emoji banner <word> <emoji>"
+		if len(parameters) == 2 {
+			return renderBanner(parameters[0], parameters[1], renderer, options)
 		}
-
-		return renderBanner(parameters[0], parameters[1], renderer, options)
 	}
 
 	return "Wrong usage: emoji banner <word> <emoji>"

--- a/plugins/emojibanner_test.go
+++ b/plugins/emojibanner_test.go
@@ -23,6 +23,19 @@ func TestEmojiBannerTrigger(t *testing.T) {
 	assert.Equal(t, true, c.Match("emoji banner cats :cat:", &slack.Msg{}))
 }
 
+func TestEmojiBannerGenerationWithWrongUsage(t *testing.T) {
+	pc := viper.New()
+
+	ebm, err := plugins.NewEmojiBannerMaker(pc)
+	assert.Nil(t, err)
+
+	defer ebm.Close()
+
+	c := ebm.Commands[0]
+
+	assert.Equal(t, "Wrong usage: emoji banner <word> <emoji>", c.Answer(&slack.Msg{Text: "emoji banner cats"}))
+}
+
 func TestEmojiBannerGenerationWithDefaultFont(t *testing.T) {
 	pc := viper.New()
 


### PR DESCRIPTION
## What is this about
Add a quick test for `emojiBannerMaker` plugin with wrong usage and simplified the `Answer`'s `returns`.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass