### PR TITLE
Clean Up Match and Answer API

### DIFF
--- a/help.go
+++ b/help.go
@@ -3,7 +3,6 @@ package slackscot
 import (
 	"fmt"
 	"github.com/alexandre-normand/slackscot/v2/config"
-	"github.com/nlopes/slack"
 	"github.com/spf13/viper"
 	"strings"
 )
@@ -41,8 +40,8 @@ func newHelpPlugin(name string, version string, viper *viper.Viper, plugins []*P
 	helpPlugin.pluginScheduledActions = scheduledActions
 
 	helpPlugin.Plugin = Plugin{Name: helpPluginName, Commands: []ActionDefinition{{
-		Match: func(t string, m *slack.Msg) bool {
-			return strings.HasPrefix(t, "help")
+		Match: func(m *IncomingMessage) bool {
+			return strings.HasPrefix(m.NormalizedText, "help")
 		},
 		Usage:       helpPluginName,
 		Description: "Reply with usage instructions",
@@ -54,7 +53,7 @@ func newHelpPlugin(name string, version string, viper *viper.Viper, plugins []*P
 
 // showHelp generates a message providing a list of all of the slackscot commands and hear actions.
 // Note that ActionDefinitions with the flag Hidden set to true won't be included in the list
-func (h *helpPlugin) showHelp(m *slack.Msg) string {
+func (h *helpPlugin) showHelp(m *IncomingMessage) string {
 	var b strings.Builder
 
 	// Get the user's first name using the botservices

--- a/plugins/emojibanner.go
+++ b/plugins/emojibanner.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/alexandre-normand/figlet4go"
 	"github.com/alexandre-normand/slackscot/v2"
-	"github.com/nlopes/slack"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"io/ioutil"
@@ -66,13 +65,13 @@ func NewEmojiBannerMaker(c *viper.Viper) (emojiBannerPlugin *EmojiBannerMaker, e
 	}
 
 	return &EmojiBannerMaker{Plugin: slackscot.Plugin{Name: EmojiBannerPluginName, Commands: []slackscot.ActionDefinition{{
-		Match: func(t string, m *slack.Msg) bool {
-			return strings.HasPrefix(t, "emoji banner")
+		Match: func(m *slackscot.IncomingMessage) bool {
+			return strings.HasPrefix(m.NormalizedText, "emoji banner")
 		},
 		Usage:       "emoji banner <word> <emoji>",
 		Description: "Renders a single-word banner with the provided emoji",
-		Answer: func(message *slack.Msg) string {
-			return validateAndRenderEmoji(message.Text, emojiBannerRegex, renderer, options)
+		Answer: func(m *slackscot.IncomingMessage) string {
+			return validateAndRenderEmoji(m.Text, emojiBannerRegex, renderer, options)
 		},
 	}}, HearActions: nil}, tempDirFontPath: tempDirFontPath}, nil
 }

--- a/plugins/emojibanner_test.go
+++ b/plugins/emojibanner_test.go
@@ -1,6 +1,7 @@
 package plugins_test
 
 import (
+	"github.com/alexandre-normand/slackscot/v2"
 	"github.com/alexandre-normand/slackscot/v2/plugins"
 	"github.com/nlopes/slack"
 	"github.com/spf13/viper"
@@ -18,9 +19,9 @@ func TestEmojiBannerTrigger(t *testing.T) {
 
 	c := ebm.Commands[0]
 
-	assert.Equal(t, false, c.Match("other", &slack.Msg{}))
-	assert.Equal(t, false, c.Match("emoji", &slack.Msg{}))
-	assert.Equal(t, true, c.Match("emoji banner cats :cat:", &slack.Msg{}))
+	assert.Equal(t, false, c.Match(&slackscot.IncomingMessage{NormalizedText: "other"}))
+	assert.Equal(t, false, c.Match(&slackscot.IncomingMessage{NormalizedText: "emoji"}))
+	assert.Equal(t, true, c.Match(&slackscot.IncomingMessage{NormalizedText: "emoji banner cats :cat:"}))
 }
 
 func TestEmojiBannerGenerationWithWrongUsage(t *testing.T) {
@@ -33,7 +34,7 @@ func TestEmojiBannerGenerationWithWrongUsage(t *testing.T) {
 
 	c := ebm.Commands[0]
 
-	assert.Equal(t, "Wrong usage: emoji banner <word> <emoji>", c.Answer(&slack.Msg{Text: "emoji banner cats"}))
+	assert.Equal(t, "Wrong usage: emoji banner <word> <emoji>", c.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "emoji banner cats"}}))
 }
 
 func TestEmojiBannerGenerationWithDefaultFont(t *testing.T) {
@@ -56,7 +57,7 @@ func TestEmojiBannerGenerationWithDefaultFont(t *testing.T) {
 		"⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️:cat:⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️:cat::cat::cat::cat::cat::cat:⬜️⬜️⬜️:cat:⬜️⬜️⬜️\n⬜️:cat::cat::cat::cat:"+
 		":cat::cat::cat::cat::cat::cat::cat::cat:⬜️⬜️⬜️⬜️⬜️:cat::cat::cat::cat:⬜️⬜️⬜️⬜️⬜️:cat::cat::cat::cat:⬜️⬜️⬜️⬜️⬜️:cat::cat::cat:"+
 		":cat::cat::cat::cat::cat::cat:⬜️⬜️⬜️⬜️\n⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️"+
-		"⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️\n", c.Answer(&slack.Msg{Text: "emoji banner cats :cat:"}))
+		"⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️\n", c.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "emoji banner cats :cat:"}}))
 }
 
 func TestEmojiBannerGenerationWithBannerFont(t *testing.T) {
@@ -75,7 +76,7 @@ func TestEmojiBannerGenerationWithBannerFont(t *testing.T) {
 		"⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️\n⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️:cat::cat::cat::cat:⬜️⬜️\n⬜️:cat:"+
 		"⬜️⬜️⬜️⬜️⬜️⬜️⬜️:cat::cat::cat::cat::cat::cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️:cat:⬜️\n⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:"+
 		"⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️\n⬜️⬜️:cat::cat::cat::cat:⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️:cat::cat::cat:"+
-		":cat:⬜️⬜️\n⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️\n", c.Answer(&slack.Msg{Text: "emoji banner cats :cat:"}))
+		":cat:⬜️⬜️\n⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️\n", c.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "emoji banner cats :cat:"}}))
 }
 
 func TestBadFontURLShouldFailPluginCreation(t *testing.T) {

--- a/plugins/fingerquoter.go
+++ b/plugins/fingerquoter.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/alexandre-normand/slackscot/v2"
 	"github.com/alexandre-normand/slackscot/v2/config"
-	"github.com/nlopes/slack"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -51,7 +50,7 @@ func NewFingerQuoter(config *config.PluginConfig) (f *FingerQuoter, err error) {
 	return f, err
 }
 
-func (f *FingerQuoter) trigger(t string, m *slack.Msg) bool {
+func (f *FingerQuoter) trigger(m *slackscot.IncomingMessage) bool {
 	if !isChannelWhiteListed(m.Channel, f.channels) {
 		return false
 	}
@@ -71,7 +70,7 @@ func (f *FingerQuoter) trigger(t string, m *slack.Msg) bool {
 	return randomGen.Int31n(int32(f.frequency)) == 0
 }
 
-func (f *FingerQuoter) fingerQuoteMsg(m *slack.Msg) string {
+func (f *FingerQuoter) fingerQuoteMsg(m *slackscot.IncomingMessage) string {
 	candidates := splitInputIntoWordsLongerThan(m.Text, 4)
 
 	if len(candidates) > 0 {

--- a/plugins/fingerquoter_test.go
+++ b/plugins/fingerquoter_test.go
@@ -35,7 +35,7 @@ func TestMatchFrequency(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		msgt := fmt.Sprintf(ts, i)
-		if h.Match("text", &slack.Msg{Timestamp: msgt}) {
+		if h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Timestamp: msgt}}) {
 			matches = matches + 1
 		}
 	}
@@ -54,9 +54,9 @@ func TestChannelWhitelisting(t *testing.T) {
 
 	h := f.HearActions[0]
 
-	assert.True(t, h.Match("text", &slack.Msg{Channel: "channel1", Timestamp: "1546833210.036900"}))
-	assert.True(t, h.Match("text", &slack.Msg{Channel: "channel2", Timestamp: "1546833210.036900"}))
-	assert.False(t, h.Match("text", &slack.Msg{Channel: "channel3", Timestamp: "1546833210.036900"}))
+	assert.True(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Channel: "channel1", Timestamp: "1546833210.036900"}}))
+	assert.True(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Channel: "channel2", Timestamp: "1546833210.036900"}}))
+	assert.False(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Channel: "channel3", Timestamp: "1546833210.036900"}}))
 }
 
 func TestDefaultWhitelistingEnablesForAll(t *testing.T) {
@@ -70,9 +70,9 @@ func TestDefaultWhitelistingEnablesForAll(t *testing.T) {
 
 	h := f.HearActions[0]
 
-	assert.True(t, h.Match("text", &slack.Msg{Channel: "channel1", Timestamp: "1546833210.036900"}))
-	assert.True(t, h.Match("text", &slack.Msg{Channel: "channel2", Timestamp: "1546833210.036900"}))
-	assert.True(t, h.Match("text", &slack.Msg{Channel: "channel3", Timestamp: "1546833210.036900"}))
+	assert.True(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Channel: "channel1", Timestamp: "1546833210.036900"}}))
+	assert.True(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Channel: "channel2", Timestamp: "1546833210.036900"}}))
+	assert.True(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Channel: "channel3", Timestamp: "1546833210.036900"}}))
 }
 
 func TestMatchConsistentWithSameTimestamp(t *testing.T) {
@@ -85,8 +85,8 @@ func TestMatchConsistentWithSameTimestamp(t *testing.T) {
 	h := f.HearActions[0]
 
 	for i := 0; i < 100; i++ {
-		assert.True(t, h.Match("text", &slack.Msg{Timestamp: "1546833210.036903"}))
-		assert.False(t, h.Match("text", &slack.Msg{Timestamp: "1546833222.031904"}))
+		assert.True(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Timestamp: "1546833210.036903"}}))
+		assert.False(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Timestamp: "1546833222.031904"}}))
 	}
 }
 
@@ -103,7 +103,7 @@ func TestMatchFalseWhenCorruptedTimestamp(t *testing.T) {
 
 	h := f.HearActions[0]
 
-	assert.False(t, h.Match("text", &slack.Msg{Channel: "channel1", Timestamp: "NotAFloatValue"}))
+	assert.False(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Channel: "channel1", Timestamp: "NotAFloatValue"}}))
 	assert.Contains(t, b.String(), "error converting timestamp to float")
 }
 
@@ -120,7 +120,7 @@ func TestNoAnswerWhenCorruptedTimestamp(t *testing.T) {
 
 	h := f.HearActions[0]
 
-	assert.Equal(t, "", h.Answer(&slack.Msg{Channel: "channel1", Timestamp: "NotAFloatValue", Text: "This is a text with longer and shorter words"}))
+	assert.Equal(t, "", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Channel: "channel1", Timestamp: "NotAFloatValue", Text: "This is a text with longer and shorter words"}}))
 	assert.Contains(t, b.String(), "error converting timestamp to float")
 }
 
@@ -133,7 +133,7 @@ func TestQuotingOfSingleLongWord(t *testing.T) {
 
 	h := f.HearActions[0]
 
-	assert.Equal(t, "\"belong\"", h.Answer(&slack.Msg{Text: "Do I belong or not?", Timestamp: "1546833210.036900"}))
+	assert.Equal(t, "\"belong\"", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "Do I belong or not?", Timestamp: "1546833210.036900"}}))
 }
 
 func TestConsistentWordQuotingWithSameTimestamp(t *testing.T) {
@@ -147,22 +147,22 @@ func TestConsistentWordQuotingWithSameTimestamp(t *testing.T) {
 	h := f.HearActions[0]
 
 	// Validate one pick with a different timestamp
-	assert.Equal(t, "\"screams\"", h.Answer(&slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
+	assert.Equal(t, "\"screams\"", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
 			Where the lock that you locked in the suite says there's no prying. When the breath that you breathed in 
-			the street screams there's no science`, Timestamp: "1546833310.036900"}))
+			the street screams there's no science`, Timestamp: "1546833310.036900"}}))
 
 	// Validate that calling the answer function a hundred times with the same timestamp results in the same pick
 	for i := 0; i < 100; i++ {
-		assert.Equal(t, "\"Where\"", h.Answer(&slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
+		assert.Equal(t, "\"Where\"", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
 			Where the lock that you locked in the suite says there's no prying. When the breath that you breathed in 
-			the street screams there's no science`, Timestamp: "1546833210.036900"}))
+			the street screams there's no science`, Timestamp: "1546833210.036900"}}))
 	}
 
 	// Validate that a timestamp *almost* equal to the prior one (except for decimals) results in something different to make sure
 	// we don't ignore those
-	assert.Equal(t, "\"Handing\"", h.Answer(&slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
+	assert.Equal(t, "\"Handing\"", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
 			Where the lock that you locked in the suite says there's no prying. When the breath that you breathed in 
-			the street screams there's no science`, Timestamp: "1546833210.036907"}))
+			the street screams there's no science`, Timestamp: "1546833210.036907"}}))
 }
 
 func TestNoQuotingIfOnlySmallWords(t *testing.T) {
@@ -174,5 +174,5 @@ func TestNoQuotingIfOnlySmallWords(t *testing.T) {
 
 	h := f.HearActions[0]
 
-	assert.Equal(t, "", h.Answer(&slack.Msg{Text: "Do I or not?", Timestamp: "1546833210.036900"}))
+	assert.Equal(t, "", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "Do I or not?", Timestamp: "1546833210.036900"}}))
 }

--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -97,8 +97,8 @@ func drivePlugin(text string, k *plugins.Karma) (matches map[string]bool, answer
 	for i, h := range k.HearActions {
 		id := fmt.Sprintf("h[%d]", i)
 
-		msg := slack.Msg{Text: text}
-		m := h.Match(text, &msg)
+		msg := slackscot.IncomingMessage{NormalizedText: text, Msg: slack.Msg{Text: text}}
+		m := h.Match(&msg)
 		matches[id] = m
 
 		if m {
@@ -109,8 +109,8 @@ func drivePlugin(text string, k *plugins.Karma) (matches map[string]bool, answer
 	for i, c := range k.Commands {
 		id := fmt.Sprintf("c[%d]", i)
 
-		msg := slack.Msg{Text: text}
-		m := c.Match(text, &msg)
+		msg := slackscot.IncomingMessage{NormalizedText: text, Msg: slack.Msg{Text: text}}
+		m := c.Match(&msg)
 		matches[id] = m
 
 		if m {

--- a/plugins/versioner.go
+++ b/plugins/versioner.go
@@ -5,7 +5,6 @@ package plugins
 import (
 	"fmt"
 	"github.com/alexandre-normand/slackscot/v2"
-	"github.com/nlopes/slack"
 	"strings"
 )
 
@@ -21,12 +20,12 @@ const (
 // NewVersioner creates a new instance of the versioner plugin
 func NewVersioner(name string, version string) *Versioner {
 	return &Versioner{Plugin: slackscot.Plugin{Name: versionerPluginName, Commands: []slackscot.ActionDefinition{{
-		Match: func(t string, m *slack.Msg) bool {
-			return strings.HasPrefix(t, "version")
+		Match: func(m *slackscot.IncomingMessage) bool {
+			return strings.HasPrefix(m.NormalizedText, "version")
 		},
 		Usage:       "version",
 		Description: fmt.Sprintf("Reply with `%s`'s `version` number", name),
-		Answer: func(m *slack.Msg) string {
+		Answer: func(m *slackscot.IncomingMessage) string {
 			return fmt.Sprintf("I'm `%s`, version `%s`", name, version)
 		}}}, HearActions: nil}}
 }

--- a/plugins/versioner_test.go
+++ b/plugins/versioner_test.go
@@ -1,8 +1,8 @@
 package plugins_test
 
 import (
+	"github.com/alexandre-normand/slackscot/v2"
 	"github.com/alexandre-normand/slackscot/v2/plugins"
-	"github.com/nlopes/slack"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -13,7 +13,7 @@ func TestSendValidVersionMessage(t *testing.T) {
 
 	vc := v.Commands[0]
 
-	msg := vc.Answer(&slack.Msg{})
+	msg := vc.Answer(&slackscot.IncomingMessage{})
 	assert.Equal(t, "I'm `little-red`, version `1.0.0`", msg)
 }
 
@@ -23,12 +23,12 @@ func TestMatchOnVersionCommand(t *testing.T) {
 
 	vc := v.Commands[0]
 
-	m := vc.Match("version", &slack.Msg{})
+	m := vc.Match(&slackscot.IncomingMessage{NormalizedText: "version"})
 	assert.Equal(t, true, m)
 
-	m = vc.Match(" version", &slack.Msg{})
+	m = vc.Match(&slackscot.IncomingMessage{NormalizedText: " version"})
 	assert.Equal(t, false, m)
 
-	m = vc.Match("version ", &slack.Msg{})
+	m = vc.Match(&slackscot.IncomingMessage{NormalizedText: "version "})
 	assert.Equal(t, true, m)
 }

--- a/slackscot.go
+++ b/slackscot.go
@@ -78,14 +78,19 @@ type ActionDefinition struct {
 	Answer Answerer
 }
 
-// Matcher is the function that determines whether or not an action should be triggered based on a slack.Msg and a
-// convenient normalized text content. Note that a match doesn't guarantee that the action should
+// Matcher is the function that determines whether or not an action should be triggered based on a IncomingMessage (which
+// includes a slack.Msg and a normalized text content. Note that a match doesn't guarantee that the action should
 // actually respond with anything once invoked
-//
-// Note: the normalized text is the Msg's text stripped out of the @Mention if this is a command and the message
-// is addressed to the bot. This is so the logic of commands doesn't have to know about the context of the
-// direct interaction (a Direct Message or an @Mention on a channel)
-type Matcher func(normalizedText string, m *slack.Msg) bool
+type Matcher func(m *IncomingMessage) bool
+
+// Answerer is what gets executed when an ActionDefinition is triggered
+type Answerer func(m *IncomingMessage) string
+
+// ActionDefinitionWithID holds an action definition along with its identifier string
+type ActionDefinitionWithID struct {
+	ActionDefinition
+	id string
+}
 
 // ScheduledActionDefinition represents when a scheduled action is triggered as well
 // as what it does and how
@@ -103,20 +108,8 @@ type ScheduledActionDefinition struct {
 	Action ScheduledAction
 }
 
-// ActionDefinitionWithID holds an action definition along with its identifier string
-type ActionDefinitionWithID struct {
-	ActionDefinition
-	id string
-}
-
-// Answerer is what gets executed when an ActionDefinition is triggered
-type Answerer func(m *slack.Msg) string
-
 // ScheduledAction is what gets executed when a ScheduledActionDefinition is triggered (by its ScheduleDefinition)
 type ScheduledAction func(sender RealTimeMessageSender)
-
-// responseStrategy defines how a slack.OutgoingMessage is generated from a response
-type responseStrategy func(m *slack.Msg, response string) *slack.OutgoingMessage
 
 // SlackMessageID holds the elements that form a unique message identifier for slack. Technically, slack also uses
 // the workspace id as the first part of that unique identifier but since an instance of slackscot only lives within
@@ -124,6 +117,20 @@ type responseStrategy func(m *slack.Msg, response string) *slack.OutgoingMessage
 type SlackMessageID struct {
 	channelID string
 	timestamp string
+}
+
+// responseStrategy defines how a slack.OutgoingMessage is generated from a response
+type responseStrategy func(m *IncomingMessage, response string) *slack.OutgoingMessage
+
+// IncomingMessage holds data for an incoming slack message. In addition to a slack.Msg, it also has
+// a normalized text that is the original text stripped from the "<@Mention>" prefix when a message
+// is addressed to a slackscot instance. Since commands are usually received either via direct message
+// (without @Mention) or on channels with @Mention, the normalized text is useful there to allow plugins
+// to have a single version to do Match and Answer against
+type IncomingMessage struct {
+	// The original slack.Msg text stripped from the "<@Mention>" prefix, if applicable
+	NormalizedText string
+	slack.Msg
 }
 
 // OutgoingMessage holds a plugin generated slack outgoing message along with the plugin identifier
@@ -167,7 +174,7 @@ func NewSlackscot(name string, v *viper.Viper, options ...Option) (s *Slackscot,
 
 	s.name = name
 	s.config = v
-	s.defaultAction = func(m *slack.Msg) string {
+	s.defaultAction = func(m *IncomingMessage) string {
 		return fmt.Sprintf("I don't understand, ask me for \"%s\" to get a list of things I do", helpPluginName)
 	}
 	s.log = NewSLogger(log.New(os.Stdout, defaultLogPrefix, defaultLogFlag), v.GetBool(config.DebugKey))
@@ -571,23 +578,19 @@ func (s *Slackscot) routeMessage(m *slack.Msg) (responses []*OutgoingMessage) {
 	}
 
 	if len(matches) == 3 {
-		if s.commandsWithID != nil {
-			omsgs := handleCommand(s.defaultAction, s.commandsWithID, matches[2], m, reply)
-			if len(omsgs) > 0 {
-				responses = append(responses, omsgs...)
-			}
-		}
-	} else if strings.HasPrefix(m.Channel, "D") {
-		if s.commandsWithID != nil {
-			omsgs := handleCommand(s.defaultAction, s.commandsWithID, m.Text, m, directReply)
-			if len(omsgs) > 0 {
-				responses = append(responses, omsgs...)
-			}
-		}
-	} else if s.hearActionsWithID != nil {
-		omsgs := handleMessage(s.hearActionsWithID, m.Text, m, send)
-		if len(omsgs) > 0 {
-			responses = append(responses, omsgs...)
+		inMsg := IncomingMessage{NormalizedText: matches[2], Msg: *m}
+
+		outMsgs := handleCommand(s.defaultAction, s.commandsWithID, &inMsg, reply)
+		responses = append(responses, outMsgs...)
+	} else {
+		inMsg := IncomingMessage{NormalizedText: m.Text, Msg: *m}
+
+		if strings.HasPrefix(m.Channel, "D") {
+			outMsgs := handleCommand(s.defaultAction, s.commandsWithID, &inMsg, directReply)
+			responses = append(responses, outMsgs...)
+		} else {
+			outMsgs := handleMessage(s.hearActionsWithID, &inMsg, send)
+			responses = append(responses, outMsgs...)
 		}
 	}
 
@@ -596,8 +599,8 @@ func (s *Slackscot) routeMessage(m *slack.Msg) (responses []*OutgoingMessage) {
 
 // handleCommand handles a command by trying a match with all known actions. If no match is found, the default action is invoked
 // Note that in the case of the default action being executed, the return value is still false to indicate no bot actions were triggered
-func handleCommand(defaultAnswer Answerer, actions []ActionDefinitionWithID, content string, m *slack.Msg, rs responseStrategy) (outMsgs []*OutgoingMessage) {
-	outMsgs = handleMessage(actions, content, m, rs)
+func handleCommand(defaultAnswer Answerer, actions []ActionDefinitionWithID, m *IncomingMessage, rs responseStrategy) (outMsgs []*OutgoingMessage) {
+	outMsgs = handleMessage(actions, m, rs)
 	if len(outMsgs) == 0 {
 		response := defaultAnswer(m)
 
@@ -611,11 +614,11 @@ func handleCommand(defaultAnswer Answerer, actions []ActionDefinitionWithID, con
 
 // processMessage loops over all action definitions and invokes its action if the incoming message matches it's regular expression
 // Note that more than one action can be triggered during the processing of a single message
-func handleMessage(actions []ActionDefinitionWithID, t string, m *slack.Msg, rs responseStrategy) (outMsgs []*OutgoingMessage) {
+func handleMessage(actions []ActionDefinitionWithID, m *IncomingMessage, rs responseStrategy) (outMsgs []*OutgoingMessage) {
 	outMsgs = make([]*OutgoingMessage, 0)
 
 	for _, action := range actions {
-		matches := action.Match(t, m)
+		matches := action.Match(m)
 
 		if matches {
 			response := action.Answer(m)
@@ -644,18 +647,18 @@ func newOutgoingMessage(channelID string, text string) *slack.OutgoingMessage {
 }
 
 // reply sends a reply to the user (using @user) who sent the message on the channel it was sent on
-func reply(replyToMsg *slack.Msg, response string) *slack.OutgoingMessage {
+func reply(replyToMsg *IncomingMessage, response string) *slack.OutgoingMessage {
 	return newOutgoingMessage(replyToMsg.Channel, fmt.Sprintf("<@%s>: %s", replyToMsg.User, response))
 }
 
 // directReply sends a reply to a direct message (which is internally a channel id for slack). It is essentially
 // the same as send but it's kept separate for clarity
-func directReply(replyToMsg *slack.Msg, response string) *slack.OutgoingMessage {
+func directReply(replyToMsg *IncomingMessage, response string) *slack.OutgoingMessage {
 	return send(replyToMsg, response)
 }
 
 // send creates a message to be sent on the same channel as received (which can be a direct message since
 // slack internally uses a channel id for private conversations)
-func send(replyToMsg *slack.Msg, response string) *slack.OutgoingMessage {
+func send(replyToMsg *IncomingMessage, response string) *slack.OutgoingMessage {
 	return newOutgoingMessage(replyToMsg.Channel, response)
 }

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -136,23 +136,23 @@ func newTestPlugin() (tp *Plugin) {
 	tp = new(Plugin)
 	tp.Name = "noRules"
 	tp.Commands = []ActionDefinition{{
-		Match: func(t string, m *slack.Msg) bool {
-			return strings.HasPrefix(t, "make")
+		Match: func(m *IncomingMessage) bool {
+			return strings.HasPrefix(m.NormalizedText, "make")
 		},
 		Usage:       "make `<something>`",
 		Description: "Have the test bot make something for you",
-		Answer: func(m *slack.Msg) string {
+		Answer: func(m *IncomingMessage) string {
 			return fmt.Sprintf("Make it yourself, @%s", m.User)
 		},
 	}}
 	tp.HearActions = []ActionDefinition{{
 		Hidden: true,
-		Match: func(t string, m *slack.Msg) bool {
-			return strings.Contains(t, "blue jays")
+		Match: func(m *IncomingMessage) bool {
+			return strings.Contains(m.NormalizedText, "blue jays")
 		},
 		Usage:       "Talk about my secret topic",
 		Description: "Reply with usage instructions",
-		Answer: func(m *slack.Msg) string {
+		Answer: func(m *IncomingMessage) string {
 			return "I heard you say something about blue jays?"
 		},
 	}}


### PR DESCRIPTION
## What is this about
Instead of passing the normalized text on `Match` only along with the
slack message and inconsistently passing only the slack `Msg` on `Answer`,
there is now a struct that embeds the `slack.Msg` and adds a normalized
version of the text and that's used in both `Match` and `Answer`.


### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass