### PR TITLE
Add Tests for Caching User Info Finder

### DIFF
--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -98,7 +98,15 @@ func (rs *realTimeSender) GetAPI() (rtm *slack.RTM) {
 type selfFinder struct {
 }
 
+func (i *selfFinder) GetInfo() (user *slack.Info) {
+	return &slack.Info{User: &slack.UserDetails{ID: "BotUserID", Name: "Daniel Quinn"}}
+}
+
 type userInfoFinder struct {
+}
+
+func (u *userInfoFinder) GetUserInfo(userID string) (user *slack.User, err error) {
+	return &slack.User{ID: botUserID, Name: "Daniel Quinn"}, nil
 }
 
 // Option type for building a message with additional options for specific test cases
@@ -159,14 +167,6 @@ func newTestPlugin() (tp *Plugin) {
 	tp.ScheduledActions = nil
 
 	return tp
-}
-
-func (i *selfFinder) GetInfo() (user *slack.Info) {
-	return &slack.Info{User: &slack.UserDetails{ID: "BotUserID", Name: "Daniel Quinn"}}
-}
-
-func (u *userInfoFinder) GetUserInfo(userID string) (user *slack.User, err error) {
-	return &slack.User{ID: botUserID, Name: "Daniel Quinn"}, nil
 }
 
 func TestLogfileOverrideUsed(t *testing.T) {

--- a/user_test.go
+++ b/user_test.go
@@ -1,0 +1,74 @@
+package slackscot_test
+
+import (
+	"fmt"
+	"github.com/alexandre-normand/slackscot/v2"
+	"github.com/alexandre-normand/slackscot/v2/config"
+	"github.com/nlopes/slack"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"log"
+	"strings"
+	"testing"
+)
+
+type userInfoFinder struct {
+	fail bool
+}
+
+func (u *userInfoFinder) GetUserInfo(userID string) (user *slack.User, err error) {
+	if u.fail {
+		return nil, fmt.Errorf("Error loading user [%s]", userID)
+	}
+
+	return &slack.User{ID: userID, Name: "Daniel Quinn"}, nil
+}
+
+func NewCachingUserInfoFinderWithInvalidSize(t *testing.T) {
+	v := viper.New()
+	v.Set(config.UserInfoCacheSizeKey, -1)
+
+	userInfoFinder := userInfoFinder{}
+	var logBuilder strings.Builder
+	logger := log.New(&logBuilder, "", 0)
+	sLogger := slackscot.NewSLogger(logger, false)
+
+	_, err := slackscot.NewCachingUserInfoFinder(v, &userInfoFinder, sLogger)
+	assert.NotNil(t, err)
+}
+
+func NewGetUserWithCacheDisabled(t *testing.T) {
+	v := viper.New()
+	v.Set(config.UserInfoCacheSizeKey, 0)
+
+	userInfoFinder := userInfoFinder{}
+	var logBuilder strings.Builder
+	logger := log.New(&logBuilder, "", 0)
+	sLogger := slackscot.NewSLogger(logger, false)
+
+	uf, err := slackscot.NewCachingUserInfoFinder(v, &userInfoFinder, sLogger)
+	if assert.Nil(t, err) {
+		user, err := uf.GetUserInfo("little-blue")
+		assert.Nil(t, err)
+
+		if assert.NotNil(t, user) {
+			assert.Equal(t, slack.User{ID: "little-blue", Name: "Daniel Quinn"}, *user)
+		}
+	}
+}
+
+func NewGetUserFailToLoad(t *testing.T) {
+	v := viper.New()
+	v.Set(config.UserInfoCacheSizeKey, 1)
+
+	userInfoFinder := userInfoFinder{}
+	var logBuilder strings.Builder
+	logger := log.New(&logBuilder, "", 0)
+	sLogger := slackscot.NewSLogger(logger, false)
+
+	uf, err := slackscot.NewCachingUserInfoFinder(v, &userInfoFinder, sLogger)
+	if assert.Nil(t, err) {
+		_, err := uf.GetUserInfo("little-blue")
+		assert.NotNil(t, err)
+	}
+}


### PR DESCRIPTION
## What is this about
Add `user_test.go` with tests of the caching user info finder.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass