### PR TITLE
Allow Answering Capabilities to be Extended in the Future

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,16 +156,17 @@ new implementation of the [storer interfaces](https://godoc.org/github.com/alexa
 ## Assembling the Parts and Bringing Your `slackscot` to Life
 
 Here's an example of how [youppi](https://github.com/alexandre-normand/youppi) 
-does it (apologies for the verbose and repetitive error handling when 
+[does it](https://github.com/alexandre-normand/youppi/blob/master/youppi.go) 
+(apologies for the verbose and repetitive error handling when 
 creating instances of plugins but it looks worse than it is):
 
 ```go
 package main
 
 import (
-	"github.com/alexandre-normand/slackscot"
-	"github.com/alexandre-normand/slackscot/config"
-	"github.com/alexandre-normand/slackscot/plugins"
+	"github.com/alexandre-normand/slackscot/v2"
+	"github.com/alexandre-normand/slackscot/v2/config"
+	"github.com/alexandre-normand/slackscot/v2/plugins"
 	"github.com/spf13/viper"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"log"
@@ -177,11 +178,21 @@ var (
 	logfile           = kingpin.Flag("log", "The path to the log file").OpenFile(os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
 )
 
+const (
+	storagePathKey = "storagePath" // Root directory for the file-based leveldb storage
+	name           = "youppi"
+)
+
 func main() {
 	kingpin.Version(VERSION)
 	kingpin.Parse()
 
 	v := config.NewViperWithDefaults()
+	// Enable getting configuration from the environment, especially useful for the slack token
+	v.AutomaticEnv()
+	// Bind the token key config to the env variable SLACK_TOKEN (case sensitive)
+	v.BindEnv(config.TokenKey, "SLACK_TOKEN")
+
 	v.SetConfigFile(*configurationPath)
 	err := v.ReadInConfig()
 	if err != nil {
@@ -201,11 +212,18 @@ func main() {
 		log.Fatal(err)
 	}
 
-	karma, err := plugins.NewKarma(v)
-	if err != nil {
-		log.Fatalf("Error initializing karma plugin: %v", err)
+	if !v.IsSet(config.StoragePathKey) {
+		return nil, fmt.Errorf("Missing [%s] configuration key in the top value configuration", config.StoragePathKey)
 	}
-	defer karma.Close()
+
+	storagePath := v.GetString(storagePathKey)
+	strStorer, err := store.NewLevelDB(name, storagePath)
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("Opening [%s] db failed with path [%s]", name, storagePath))
+	}
+	defer strStorer.Close()
+
+	karma, err := plugins.NewKarma(strStorer)
 	youppi.RegisterPlugin(&karma.Plugin)
 
 	fingerQuoterConf, err := config.GetPluginConfig(v, plugins.FingerQuoterPluginName)
@@ -217,9 +235,6 @@ func main() {
 		log.Fatalf("Error initializing finger quoter plugin: %v", err)
 	}
 	youppi.RegisterPlugin(&fingerQuoter.Plugin)
-
-	imager := plugins.NewImager()
-	youppi.RegisterPlugin(&imager.Plugin)
 
 	emojiBannerConf, err := config.GetPluginConfig(v, plugins.EmojiBannerPluginName)
 	if err != nil {

--- a/help.go
+++ b/help.go
@@ -54,7 +54,7 @@ func newHelpPlugin(name string, version string, viper *viper.Viper, plugins []*P
 
 // showHelp generates a message providing a list of all of the slackscot commands and hear actions.
 // Note that ActionDefinitions with the flag Hidden set to true won't be included in the list
-func (h *helpPlugin) showHelp(m *IncomingMessage) string {
+func (h *helpPlugin) showHelp(m *IncomingMessage) *Answer {
 	var b strings.Builder
 
 	// Get the user's first name using the botservices
@@ -86,7 +86,7 @@ func (h *helpPlugin) showHelp(m *IncomingMessage) string {
 		appendScheduledActions(&b, h.v.GetString(config.TimeLocationKey), h.pluginScheduledActions)
 	}
 
-	return b.String()
+	return &Answer{Text: b.String()}
 }
 
 func appendActions(w io.Writer, actions []ActionDefinition) {

--- a/plugins/emojibanner_test.go
+++ b/plugins/emojibanner_test.go
@@ -34,7 +34,7 @@ func TestEmojiBannerGenerationWithWrongUsage(t *testing.T) {
 
 	c := ebm.Commands[0]
 
-	assert.Equal(t, "Wrong usage: emoji banner <word> <emoji>", c.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "emoji banner cats"}}))
+	assert.Equal(t, "Wrong usage: emoji banner <word> <emoji>", c.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "emoji banner cats"}}).Text)
 }
 
 func TestEmojiBannerGenerationWithDefaultFont(t *testing.T) {
@@ -57,7 +57,7 @@ func TestEmojiBannerGenerationWithDefaultFont(t *testing.T) {
 		"⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️:cat:⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️:cat::cat::cat::cat::cat::cat:⬜️⬜️⬜️:cat:⬜️⬜️⬜️\n⬜️:cat::cat::cat::cat:"+
 		":cat::cat::cat::cat::cat::cat::cat::cat:⬜️⬜️⬜️⬜️⬜️:cat::cat::cat::cat:⬜️⬜️⬜️⬜️⬜️:cat::cat::cat::cat:⬜️⬜️⬜️⬜️⬜️:cat::cat::cat:"+
 		":cat::cat::cat::cat::cat::cat:⬜️⬜️⬜️⬜️\n⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️"+
-		"⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️\n", c.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "emoji banner cats :cat:"}}))
+		"⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️\n", c.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "emoji banner cats :cat:"}}).Text)
 }
 
 func TestEmojiBannerGenerationWithBannerFont(t *testing.T) {
@@ -76,7 +76,7 @@ func TestEmojiBannerGenerationWithBannerFont(t *testing.T) {
 		"⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️\n⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️:cat::cat::cat::cat:⬜️⬜️\n⬜️:cat:"+
 		"⬜️⬜️⬜️⬜️⬜️⬜️⬜️:cat::cat::cat::cat::cat::cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️:cat:⬜️\n⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:"+
 		"⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️\n⬜️⬜️:cat::cat::cat::cat:⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️:cat::cat::cat:"+
-		":cat:⬜️⬜️\n⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️\n", c.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "emoji banner cats :cat:"}}))
+		":cat:⬜️⬜️\n⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️\n", c.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "emoji banner cats :cat:"}}).Text)
 }
 
 func TestBadFontURLShouldFailPluginCreation(t *testing.T) {

--- a/plugins/fingerquoter.go
+++ b/plugins/fingerquoter.go
@@ -70,7 +70,7 @@ func (f *FingerQuoter) trigger(m *slackscot.IncomingMessage) bool {
 	return randomGen.Int31n(int32(f.frequency)) == 0
 }
 
-func (f *FingerQuoter) fingerQuoteMsg(m *slackscot.IncomingMessage) string {
+func (f *FingerQuoter) fingerQuoteMsg(m *slackscot.IncomingMessage) *slackscot.Answer {
 	candidates := splitInputIntoWordsLongerThan(m.Text, 4)
 
 	if len(candidates) > 0 {
@@ -84,12 +84,12 @@ func (f *FingerQuoter) fingerQuoteMsg(m *slackscot.IncomingMessage) string {
 			randomGen := rand.New(rand.NewSource(int64(fullTs)))
 
 			i := randomGen.Int31n(int32(len(candidates)))
-			return fmt.Sprintf("\"%s\"", candidates[i])
+			return &slackscot.Answer{Text: fmt.Sprintf("\"%s\"", candidates[i])}
 		}
 	}
 
 	// Not this time, skip
-	return ""
+	return &slackscot.Answer{Text: ""}
 }
 
 func splitInputIntoWordsLongerThan(t string, minLen int) []string {

--- a/plugins/fingerquoter_test.go
+++ b/plugins/fingerquoter_test.go
@@ -120,7 +120,7 @@ func TestNoAnswerWhenCorruptedTimestamp(t *testing.T) {
 
 	h := f.HearActions[0]
 
-	assert.Equal(t, "", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Channel: "channel1", Timestamp: "NotAFloatValue", Text: "This is a text with longer and shorter words"}}))
+	assert.Equal(t, "", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Channel: "channel1", Timestamp: "NotAFloatValue", Text: "This is a text with longer and shorter words"}}).Text)
 	assert.Contains(t, b.String(), "error converting timestamp to float")
 }
 
@@ -133,7 +133,7 @@ func TestQuotingOfSingleLongWord(t *testing.T) {
 
 	h := f.HearActions[0]
 
-	assert.Equal(t, "\"belong\"", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "Do I belong or not?", Timestamp: "1546833210.036900"}}))
+	assert.Equal(t, "\"belong\"", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "Do I belong or not?", Timestamp: "1546833210.036900"}}).Text)
 }
 
 func TestConsistentWordQuotingWithSameTimestamp(t *testing.T) {
@@ -149,20 +149,20 @@ func TestConsistentWordQuotingWithSameTimestamp(t *testing.T) {
 	// Validate one pick with a different timestamp
 	assert.Equal(t, "\"screams\"", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
 			Where the lock that you locked in the suite says there's no prying. When the breath that you breathed in 
-			the street screams there's no science`, Timestamp: "1546833310.036900"}}))
+			the street screams there's no science`, Timestamp: "1546833310.036900"}}).Text)
 
 	// Validate that calling the answer function a hundred times with the same timestamp results in the same pick
 	for i := 0; i < 100; i++ {
 		assert.Equal(t, "\"Where\"", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
 			Where the lock that you locked in the suite says there's no prying. When the breath that you breathed in 
-			the street screams there's no science`, Timestamp: "1546833210.036900"}}))
+			the street screams there's no science`, Timestamp: "1546833210.036900"}}).Text)
 	}
 
 	// Validate that a timestamp *almost* equal to the prior one (except for decimals) results in something different to make sure
 	// we don't ignore those
 	assert.Equal(t, "\"Handing\"", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
 			Where the lock that you locked in the suite says there's no prying. When the breath that you breathed in 
-			the street screams there's no science`, Timestamp: "1546833210.036907"}}))
+			the street screams there's no science`, Timestamp: "1546833210.036907"}}).Text)
 }
 
 func TestNoQuotingIfOnlySmallWords(t *testing.T) {
@@ -174,5 +174,5 @@ func TestNoQuotingIfOnlySmallWords(t *testing.T) {
 
 	h := f.HearActions[0]
 
-	assert.Equal(t, "", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "Do I or not?", Timestamp: "1546833210.036900"}}))
+	assert.Equal(t, "", h.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "Do I or not?", Timestamp: "1546833210.036900"}}).Text)
 }

--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -77,7 +77,7 @@ func drivePlugin(text string, k *plugins.Karma) (matches map[string]bool, answer
 		matches[id] = m
 
 		if m {
-			answers[id] = h.Answer(&msg)
+			answers[id] = h.Answer(&msg).Text
 		}
 	}
 
@@ -89,7 +89,7 @@ func drivePlugin(text string, k *plugins.Karma) (matches map[string]bool, answer
 		matches[id] = m
 
 		if m {
-			answers[id] = c.Answer(&msg)
+			answers[id] = c.Answer(&msg).Text
 		}
 	}
 

--- a/plugins/versioner.go
+++ b/plugins/versioner.go
@@ -25,7 +25,7 @@ func NewVersioner(name string, version string) *Versioner {
 		},
 		Usage:       "version",
 		Description: fmt.Sprintf("Reply with `%s`'s `version` number", name),
-		Answer: func(m *slackscot.IncomingMessage) string {
-			return fmt.Sprintf("I'm `%s`, version `%s`", name, version)
+		Answer: func(m *slackscot.IncomingMessage) *slackscot.Answer {
+			return &slackscot.Answer{Text: fmt.Sprintf("I'm `%s`, version `%s`", name, version)}
 		}}}, HearActions: nil}}
 }

--- a/plugins/versioner_test.go
+++ b/plugins/versioner_test.go
@@ -13,8 +13,8 @@ func TestSendValidVersionMessage(t *testing.T) {
 
 	vc := v.Commands[0]
 
-	msg := vc.Answer(&slackscot.IncomingMessage{})
-	assert.Equal(t, "I'm `little-red`, version `1.0.0`", msg)
+	answer := vc.Answer(&slackscot.IncomingMessage{})
+	assert.Equal(t, "I'm `little-red`, version `1.0.0`", answer.Text)
 }
 
 func TestMatchOnVersionCommand(t *testing.T) {

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -149,8 +149,8 @@ func newTestPlugin() (tp *Plugin) {
 		},
 		Usage:       "make `<something>`",
 		Description: "Have the test bot make something for you",
-		Answer: func(m *IncomingMessage) string {
-			return fmt.Sprintf("Make it yourself, @%s", m.User)
+		Answer: func(m *IncomingMessage) *Answer {
+			return &Answer{Text: fmt.Sprintf("Make it yourself, @%s", m.User)}
 		},
 	}}
 	tp.HearActions = []ActionDefinition{{
@@ -160,8 +160,8 @@ func newTestPlugin() (tp *Plugin) {
 		},
 		Usage:       "Talk about my secret topic",
 		Description: "Reply with usage instructions",
-		Answer: func(m *IncomingMessage) string {
-			return "I heard you say something about blue jays?"
+		Answer: func(m *IncomingMessage) *Answer {
+			return &Answer{Text: "I heard you say something about blue jays?"}
 		},
 	}}
 	tp.ScheduledActions = nil


### PR DESCRIPTION
## What is this about
Made `Answerer` return an `Answer` struct that can be more amenable to adding capabilities in the future (like message options to allow a plugin action to decide to do threaded replying, for example). It should be easy to add but I want to sleep on it to not just stick an array of `slack.MsgOption` in there which would make it hard on plugin authors to test (because of how MsgOptions are functions acting on a `slack` private struct). 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass