### PR TITLE
Add Ability for Actions to Reply in Threads With/Without Broadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ your ambitious dreams (if you dreams include this sort of thing).
     `broadcast` on channels (disabled by `default`). 
     See [configuration example](#configuration-example) below where 
     both are enabled. 
+    *   Plugin actions may also explicitely reply in threads with/without
+        broadcasting via [AnswerOption](answer.go)
 
 *   Simple extensible storage `API` for persistence in two flavors: 
     `StringStorer` and `BytesStorer`. Both are basic `key:value` maps. 

--- a/answer.go
+++ b/answer.go
@@ -1,0 +1,49 @@
+package slackscot
+
+const (
+	ThreadedReplyOpt = "threadedReply"
+	BroadcastOpt     = "broadcast"
+)
+
+// AnswerOption defines a function applied to Answers
+type AnswerOption func(sendOpts map[string]string)
+
+// AnswerInThread sets threaded replying
+func AnswerInThread() func(sendOpts map[string]string) {
+	return func(sendOpts map[string]string) {
+		sendOpts[ThreadedReplyOpt] = "true"
+	}
+}
+
+// AnswerInThreadWithBroadcast sets threaded replying with broadcast enabled
+func AnswerInThreadWithBroadcast() func(sendOpts map[string]string) {
+	return func(sendOpts map[string]string) {
+		sendOpts[ThreadedReplyOpt] = "true"
+		sendOpts[BroadcastOpt] = "true"
+	}
+}
+
+// AnswerInThreadWithoutBroadcast sets threaded replying with broadcast disabled
+func AnswerInThreadWithoutBroadcast() func(sendOpts map[string]string) {
+	return func(sendOpts map[string]string) {
+		sendOpts[ThreadedReplyOpt] = "true"
+		sendOpts[BroadcastOpt] = "false"
+	}
+}
+
+// AnswerWithoutThreading
+func AnswerWithoutThreading() func(sendOpts map[string]string) {
+	return func(sendOpts map[string]string) {
+		sendOpts[ThreadedReplyOpt] = "false"
+	}
+}
+
+// ApplyAnswerOpts applies answering options to build the send configuration
+func ApplyAnswerOpts(opts ...AnswerOption) (sendOptions map[string]string) {
+	sendOptions = make(map[string]string)
+	for _, opt := range opts {
+		opt(sendOptions)
+	}
+
+	return sendOptions
+}

--- a/answer_test.go
+++ b/answer_test.go
@@ -1,0 +1,28 @@
+package slackscot_test
+
+import (
+	"github.com/alexandre-normand/slackscot"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestApplyAnswerOptions(t *testing.T) {
+	testCases := []struct {
+		name           string
+		options        []slackscot.AnswerOption
+		expectedConfig map[string]string
+	}{
+		{"none", []slackscot.AnswerOption{}, make(map[string]string)},
+		{"threadedReply", []slackscot.AnswerOption{slackscot.AnswerInThread()}, map[string]string{slackscot.ThreadedReplyOpt: "true"}},
+		{"threadedReplyWithBroadcast", []slackscot.AnswerOption{slackscot.AnswerInThreadWithBroadcast()}, map[string]string{slackscot.ThreadedReplyOpt: "true", slackscot.BroadcastOpt: "true"}},
+		{"threadedReplyWithoutBroadcast", []slackscot.AnswerOption{slackscot.AnswerInThreadWithoutBroadcast()}, map[string]string{slackscot.ThreadedReplyOpt: "true", slackscot.BroadcastOpt: "false"}},
+		{"noThreading", []slackscot.AnswerOption{slackscot.AnswerWithoutThreading()}, map[string]string{slackscot.ThreadedReplyOpt: "false"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := slackscot.ApplyAnswerOpts(tc.options...)
+			assert.Equal(t, tc.expectedConfig, c)
+		})
+	}
+}

--- a/help.go
+++ b/help.go
@@ -86,7 +86,7 @@ func (h *helpPlugin) showHelp(m *IncomingMessage) *Answer {
 		appendScheduledActions(&b, h.v.GetString(config.TimeLocationKey), h.pluginScheduledActions)
 	}
 
-	return &Answer{Text: b.String()}
+	return &Answer{Text: b.String(), Options: []AnswerOption{AnswerInThreadWithBroadcast()}}
 }
 
 func appendActions(w io.Writer, actions []ActionDefinition) {

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -460,10 +460,10 @@ func TestHelpTriggeringWithUserInfoCache(t *testing.T) {
 	v := config.NewViperWithDefaults()
 	v.Set(config.UserInfoCacheSizeKey, 10)
 
-	testhelpTriggering(t, v)
+	testHelpTriggering(t, v)
 }
 
-func testhelpTriggering(t *testing.T, v *viper.Viper) {
+func testHelpTriggering(t *testing.T, v *viper.Viper) {
 	sentMsgs, updatedMsgs, deletedMsgs, rtmSender, _ := runSlackscotWithIncomingEventsWithLogs(t, v, newTestPlugin(), []slack.RTMEvent{
 		// Trigger the help on a channel
 		newRTMMessageEvent(newMessageEvent("Cgeneral", fmt.Sprintf("<@%s> help", botUserID), "Alphonse", timestamp1)),
@@ -472,10 +472,10 @@ func testhelpTriggering(t *testing.T, v *viper.Viper) {
 	})
 
 	if assert.Equal(t, 2, len(sentMsgs)) {
-		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 5, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
-		assert.Equal(t, 3, len(sentMsgs[1].msgOptions))
+		assert.Equal(t, 5, len(sentMsgs[1].msgOptions))
 		assert.Equal(t, "DFromAlphonse", sentMsgs[1].channelID)
 	}
 
@@ -490,7 +490,7 @@ func TestHelpTriggeringNoUserInfoCache(t *testing.T) {
 	v := config.NewViperWithDefaults()
 	v.Set(config.UserInfoCacheSizeKey, 0)
 
-	testhelpTriggering(t, v)
+	testHelpTriggering(t, v)
 }
 
 func TestTriggeringMessageDeletion(t *testing.T) {
@@ -570,10 +570,7 @@ func TestScheduledAction(t *testing.T) {
 		assert.Equal(t, rtmMessage{channelID: "Cstatus", message: "beat"}, rtmSender.rtmMsgs[0])
 	}
 
-	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
-	}
-
+	assert.Equal(t, 1, len(sentMsgs))
 	assert.Equal(t, 0, len(updatedMsgs))
 	assert.Equal(t, 0, len(deletedMsgs))
 }

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.0.0"
+	VERSION = "1.1.0"
 )


### PR DESCRIPTION
## What is this about
This adds the ability for plugins to dictate if the `Answer` should be sent as a threaded reply with broadcast or not. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass