### PR TITLE
Add Multi-Channel Support to Oh Monday

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,11 +292,11 @@ which means that you are free to use a different file format
    },
    "plugins": {
       "ohMonday": {
-   	     "channelId": "slackChannelId"
+   	     "channelIDs": ["slackChannelId"]
       },
       "fingerQuoter": {
          "frequency": "100",
-         "channelIds": ""
+         "channelIDs": []
       },
       "emojiBanner": {
          "figletFontUrl": "http://www.figlet.org/fonts/banner.flf"

--- a/plugins/fingerquoter.go
+++ b/plugins/fingerquoter.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	channelIDsKey = "channelIds"
+	channelIDsKey = "channelIDs"
 	frequencyKey  = "frequency"
 )
 
@@ -34,8 +34,8 @@ func NewFingerQuoter(config *config.PluginConfig) (f *FingerQuoter, err error) {
 	}
 
 	f = new(FingerQuoter)
-	channelValue := config.GetString(channelIDsKey)
-	f.channels = strings.Split(channelValue, ",")
+	f.channels = config.GetStringSlice(channelIDsKey)
+	fmt.Printf("CHannels (%d)\n", len(f.channels))
 	f.frequency = config.GetInt(frequencyKey)
 	f.Name = FingerQuoterPluginName
 	f.HearActions = []slackscot.ActionDefinition{{

--- a/plugins/fingerquoter_test.go
+++ b/plugins/fingerquoter_test.go
@@ -47,7 +47,7 @@ func TestChannelWhitelisting(t *testing.T) {
 	pc := viper.New()
 	// With a frequency of 1, every message should match if whitelist is on
 	pc.Set("frequency", 1)
-	pc.Set("channelIds", "channel1,channel2")
+	pc.Set("channelIds", []string{"channel1", "channel2"})
 
 	f, err := plugins.NewFingerQuoter(pc)
 	assert.Nil(t, err)

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.1.0"
+	VERSION = "1.2.0"
 )


### PR DESCRIPTION
## What is this about
Add support for a list of channel ids to send a greeting to to the `Oh Monday` plugin.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass