### PR TITLE
Limit Emoji Banners to 5 Characters

### DIFF
--- a/plugins/emojibanner.go
+++ b/plugins/emojibanner.go
@@ -68,7 +68,7 @@ func NewEmojiBannerMaker(c *config.PluginConfig) (emojiBannerPlugin *EmojiBanner
 		Match: func(m *slackscot.IncomingMessage) bool {
 			return strings.HasPrefix(m.NormalizedText, "emoji banner")
 		},
-		Usage:       "emoji banner <word> <emoji>",
+		Usage:       "emoji banner <word of 5 characters or less> <emoji>",
 		Description: "Renders a single-word banner with the provided emoji",
 		Answer: func(m *slackscot.IncomingMessage) *slackscot.Answer {
 			return validateAndRenderEmoji(m.Text, emojiBannerRegex, renderer, options)
@@ -121,11 +121,18 @@ func validateAndRenderEmoji(message string, regex *regexp.Regexp, renderer *figl
 		parameters := strings.Split(commandParameters[2], " ")
 
 		if len(parameters) == 2 {
-			return renderBanner(parameters[0], parameters[1], renderer, options)
+			word := parameters[0]
+			emoji := parameters[1]
+
+			if len(word) < 5 {
+				return renderBanner(word, emoji, renderer, options)
+			} else {
+				return &slackscot.Answer{Text: "Wrong usage (word longer than 5 characters): emoji banner <word of 5 characters or less> <emoji>"}
+			}
 		}
 	}
 
-	return &slackscot.Answer{Text: "Wrong usage: emoji banner <word> <emoji>"}
+	return &slackscot.Answer{Text: "Wrong usage: emoji banner <word of 5 characters or less> <emoji>"}
 }
 
 func renderBanner(word, emoji string, renderer *figlet4go.AsciiRender, options *figlet4go.RenderOptions) *slackscot.Answer {

--- a/plugins/emojibanner_test.go
+++ b/plugins/emojibanner_test.go
@@ -34,7 +34,20 @@ func TestEmojiBannerGenerationWithWrongUsage(t *testing.T) {
 
 	c := ebm.Commands[0]
 
-	assert.Equal(t, "Wrong usage: emoji banner <word> <emoji>", c.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "emoji banner cats"}}).Text)
+	assert.Equal(t, "Wrong usage: emoji banner <word of 5 characters or less> <emoji>", c.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "emoji banner cats"}}).Text)
+}
+
+func TestEmojiBannerGenerationWithLongWord(t *testing.T) {
+	pc := viper.New()
+
+	ebm, err := plugins.NewEmojiBannerMaker(pc)
+	assert.Nil(t, err)
+
+	defer ebm.Close()
+
+	c := ebm.Commands[0]
+
+	assert.Equal(t, "Wrong usage (word longer than 5 characters): emoji banner <word of 5 characters or less> <emoji>", c.Answer(&slackscot.IncomingMessage{Msg: slack.Msg{Text: "emoji banner testing :bug:"}}).Text)
 }
 
 func TestEmojiBannerGenerationWithDefaultFont(t *testing.T) {

--- a/plugins/fingerquoter.go
+++ b/plugins/fingerquoter.go
@@ -35,7 +35,6 @@ func NewFingerQuoter(config *config.PluginConfig) (f *FingerQuoter, err error) {
 
 	f = new(FingerQuoter)
 	f.channels = config.GetStringSlice(channelIDsKey)
-	fmt.Printf("CHannels (%d)\n", len(f.channels))
 	f.frequency = config.GetInt(frequencyKey)
 	f.Name = FingerQuoterPluginName
 	f.HearActions = []slackscot.ActionDefinition{{

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.2.0"
+	VERSION = "1.3.0"
 )


### PR DESCRIPTION
## What is this about
Limit emoji banner to words of 5 characters or less.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass