### PR TITLE
Add Support for User Ids, Hyphens and Apostrophes in Karma

### DIFF
--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.3.0"
+	VERSION = "1.4.0"
 )


### PR DESCRIPTION
## What is this about
Tweak `karma` to allow hyphens, apostrophes and user ids (rendered using the user's real name).

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass