### PR TITLE
Fix Fetching User Info in Karma Plugin

### DIFF
--- a/plugins/karma.go
+++ b/plugins/karma.go
@@ -121,7 +121,7 @@ func (k *Karma) recordKarma(message *slackscot.IncomingMessage) *slackscot.Answe
 // and returns that instead (if found a match)
 func (k *Karma) renderThing(thing string) (renderedThing string) {
 	if strings.HasPrefix(thing, "@") {
-		u, _ := k.UserInfoFinder.GetUserInfo(thing)
+		u, _ := k.UserInfoFinder.GetUserInfo(strings.TrimPrefix(thing, "@"))
 
 		if u != nil {
 			return u.RealName

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.4.1"
+	VERSION = "1.4.2"
 )


### PR DESCRIPTION
## What is this about
The `user id` to get the user details for `karma` was using the `@` prefix but the real user id is what comes after.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass