### PR TITLE
Fix Message Update Trigerring New Threaded Reply Message

### DIFF
--- a/slackscot.go
+++ b/slackscot.go
@@ -463,7 +463,7 @@ func (s *Slackscot) processUpdatedMessageWithCachedResponses(driver chatDriver, 
 			s.log.Debugf("New response triggered to updated message [%s] [%s]: [%s]\n", o.OutgoingMessage.Text, r, o.OutgoingMessage.Text)
 
 			// It's a new message for that action so post it as a new message
-			rID, err := s.sendNewMessage(driver, o, incomingMessageID.timestamp)
+			rID, err := s.sendNewMessage(driver, o, editedSlackMessageID.timestamp)
 			if err != nil {
 				s.log.Printf("Unable to send new message to updated message [%s]: %v\n", r, err)
 			} else {

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.5.0"
+	VERSION = "1.5.1"
 )


### PR DESCRIPTION
### What is this about

There was a bug where new messages triggered on a message update would not show up if the configuration or the plugin made it such that this would be a threaded reply. The problem was that the thread timestamp was wrong and therefore no message existed to issue a threaded reply to. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass