### PR TITLE
Use Downsized Oh Monday Gifs for Ultra Large Ones

### DIFF
--- a/plugins/ohmonday.go
+++ b/plugins/ohmonday.go
@@ -16,11 +16,11 @@ const (
 	ohMondayChannelIDsKey = "channelIDs"
 )
 
-var mondayPictures = []string{"https://media.giphy.com/media/3og0IHx11gZBccA98c/giphy.gif",
+var mondayPictures = []string{"https://media.giphy.com/media/3og0IHx11gZBccA98c/giphy-downsized-large.gif",
 	"https://media.giphy.com/media/vguRpQzGag7M5h4UVt/giphy.gif",
-	"https://media.giphy.com/media/9GI7UlOQ6uU95v82q7/giphy.gif",
+	"https://media.giphy.com/media/9GI7UlOQ6uU95v82q7/giphy-downsized-large.gif",
 	"https://media.giphy.com/media/hu3Z1fwuOZh3a/giphy.gif",
-	"https://media.giphy.com/media/5ZZSYqvcH6QppFQGI5/giphy.gif",
+	"https://media.giphy.com/media/5ZZSYqvcH6QppFQGI5/giphy-downsized-large.gif",
 	"https://media.giphy.com/media/7mMRX7gWzDVwA/giphy.gif",
 	"https://media.giphy.com/media/Mv6t9sASpgTEA/giphy.gif",
 	"https://media.giphy.com/media/GGFMa2baxgoLK/giphy.gif",

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.5.1"
+	VERSION = "1.5.2"
 )


### PR DESCRIPTION
## What is this about
Use downsized `gif` links for the ultra-large gifs (`>10 MB`).

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass