### PR TITLE
Add ignoredChannelIDs to Finger Quoter Plugin Configuration

### DIFF
--- a/plugins/fingerquoter_test.go
+++ b/plugins/fingerquoter_test.go
@@ -47,7 +47,7 @@ func TestChannelWhitelisting(t *testing.T) {
 	pc := viper.New()
 	// With a frequency of 1, every message should match if whitelist is on
 	pc.Set("frequency", 1)
-	pc.Set("channelIds", []string{"channel1", "channel2"})
+	pc.Set("channelIDs", []string{"channel1", "channel2"})
 
 	f, err := plugins.NewFingerQuoter(pc)
 	assert.Nil(t, err)
@@ -59,11 +59,45 @@ func TestChannelWhitelisting(t *testing.T) {
 	assert.False(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Channel: "channel3", Timestamp: "1546833210.036900"}}))
 }
 
+func TestChannelIgnoring(t *testing.T) {
+	pc := viper.New()
+	// With a frequency of 1, every message should match if whitelist is on
+	pc.Set("frequency", 1)
+	pc.Set("channelIDs", []string{"channel1", "channel2"})
+	pc.Set("ignoredChannelIDs", []string{"channel2"})
+
+	f, err := plugins.NewFingerQuoter(pc)
+	assert.Nil(t, err)
+
+	h := f.HearActions[0]
+
+	assert.True(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Channel: "channel1", Timestamp: "1546833210.036900"}}))
+	assert.False(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Channel: "channel2", Timestamp: "1546833210.036900"}}))
+	assert.False(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Channel: "channel3", Timestamp: "1546833210.036900"}}))
+}
+
+func TestChannelIgnoredWithDefaultWhitelisting(t *testing.T) {
+	pc := viper.New()
+	// With a frequency of 1, every message should match if whitelist is on
+	pc.Set("frequency", 1)
+	pc.Set("channelIDs", "")
+	pc.Set("ignoredChannelIDs", []string{"channel2"})
+
+	f, err := plugins.NewFingerQuoter(pc)
+	assert.Nil(t, err)
+
+	h := f.HearActions[0]
+
+	assert.True(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Channel: "channel1", Timestamp: "1546833210.036900"}}))
+	assert.False(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Channel: "channel2", Timestamp: "1546833210.036900"}}))
+	assert.True(t, h.Match(&slackscot.IncomingMessage{NormalizedText: "text", Msg: slack.Msg{Channel: "channel3", Timestamp: "1546833210.036900"}}))
+}
+
 func TestDefaultWhitelistingEnablesForAll(t *testing.T) {
 	pc := viper.New()
 	// With a frequency of 1, every message should match if whitelist is on
 	pc.Set("frequency", 1)
-	pc.Set("channelIds", "")
+	pc.Set("channelIDs", "")
 
 	f, err := plugins.NewFingerQuoter(pc)
 	assert.Nil(t, err)
@@ -139,7 +173,7 @@ func TestQuotingOfSingleLongWord(t *testing.T) {
 func TestConsistentWordQuotingWithSameTimestamp(t *testing.T) {
 	pc := viper.New()
 	pc.Set("frequency", 10)
-	pc.Set("channelIds", "")
+	pc.Set("channelIDs", "")
 
 	f, err := plugins.NewFingerQuoter(pc)
 	assert.Nil(t, err)

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.5.2"
+	VERSION = "1.6.0"
 )


### PR DESCRIPTION
## What is this about
Added `ignoredChannelIDs` configuration to finger quoting to allow a _opt-out_ style instead of `opt-in`. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass