### PR TITLE
Only Process Commands on Direct Message and Message with @selfUserId

### DIFF
--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.9.0"
+	VERSION = "1.9.1"
 )


### PR DESCRIPTION
## What is this about
Drop command processing when messages start with '@selfName' or 'selfName'. I never liked those and it makes the parsing simpler (a `HasPrefix` instead of a regex). 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass