### PR TITLE
Have Message Updates Use the Original Message's Timestamp

### DIFF
--- a/slackscot.go
+++ b/slackscot.go
@@ -579,12 +579,16 @@ func (s *Slackscot) updateExistingMessage(updater messageUpdater, r SlackMessage
 
 // combineIncomingMessageForHandling combines a main message and its sub message to form what would be an intuitive message to process for
 // a bot. That is, a message with the new updated text (since we're talking about a changed message) along with the channel being the one where the message
-// is visible and with the user correctly set to the person who updated/sent the message. Essentially, take everything from the main message except
-// for the text and user that is set on the SubMessage
+// is visible and with the user correctly set to the person who updated/sent the message. We also take the timestamp of the original message to make
+// it convenient for plugins using the timestamp to know that they're looking at the same one they've seen before. Regarding this timestamp, we sort of treat
+// is like the identifier that it is which would be initialized when first posted.
+//
+// Essentially, take everything from the main message except for the text, user and timestamp that is set on the SubMessage
 func combineIncomingMessage(messageEvent *slack.MessageEvent) (combinedMessage *slack.Msg) {
 	combined := messageEvent.Msg
 	combined.Text = messageEvent.SubMessage.Text
 	combined.User = messageEvent.SubMessage.User
+	combined.Timestamp = messageEvent.SubMessage.Timestamp
 	return &combined
 }
 

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -163,7 +163,9 @@ func newTestPlugin() (tp *Plugin) {
 	tp.HearActions = []ActionDefinition{{
 		Hidden: true,
 		Match: func(m *IncomingMessage) bool {
-			return strings.Contains(m.NormalizedText, "blue jays")
+			// Only match if the message timestamp matches timestamp1 (the original time). We use this to make sure
+			// that slackscot preserves the original message's timestamp when processing message updates
+			return m.Msg.Timestamp == timestamp1 && strings.Contains(m.NormalizedText, "blue jays")
 		},
 		Usage:       "Talk about my secret topic",
 		Description: "Reply with usage instructions",

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.9.1"
+	VERSION = "1.9.2"
 )


### PR DESCRIPTION
## What is this about
Since the `Timestamp` is part of a message identification, `slackscot`
now uses the `timestamp` of the original message when processing message
updates. This is useful because plugins can use this to know when looking
at a message that it's the same as one previously seen.

One example of this is the `fingerquoter` that uses the timestamp as a seed to
random generation to decide on a match/trigger. Previously, a message update
would result in a different seed which would cause the previous reaction to be
deleted. Now `fingerquoter` can remain coherent as it sees the same timestamp/seed
which results in the same match/non-match. The reaction can change depending on the
message content changing but that seems consistent and reasonable too.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass