### PR TITLE
Tweak Finger Quoter's Finding of Word Candidates to Exclude Words in Non-Sentence Messages

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -1,8 +1,10 @@
 package slackscot
 
 const (
+	// ThreadedReplyOpt is the name of the option indicating a threaded-reply answer
 	ThreadedReplyOpt = "threadedReply"
-	BroadcastOpt     = "broadcast"
+	// BroadcastOpt is the name of the option indicating a broadcast answer
+	BroadcastOpt = "broadcast"
 )
 
 // AnswerOption defines a function applied to Answers

--- a/plugins/emojibanner.go
+++ b/plugins/emojibanner.go
@@ -126,9 +126,9 @@ func validateAndRenderEmoji(message string, regex *regexp.Regexp, renderer *figl
 
 			if len(word) < 5 {
 				return renderBanner(word, emoji, renderer, options)
-			} else {
-				return &slackscot.Answer{Text: "Wrong usage (word longer than 5 characters): emoji banner <word of 5 characters or less> <emoji>"}
 			}
+
+			return &slackscot.Answer{Text: "Wrong usage (word longer than 5 characters): emoji banner <word of 5 characters or less> <emoji>"}
 		}
 	}
 

--- a/plugins/triggerer.go
+++ b/plugins/triggerer.go
@@ -214,7 +214,7 @@ func (t *Triggerer) matchTriggers(m *slackscot.IncomingMessage) bool {
 	}
 
 	for _, triggers := range triggersByType {
-		for trigger, _ := range triggers {
+		for trigger := range triggers {
 			if strings.Contains(m.NormalizedText, trigger) {
 				return true
 			}
@@ -443,7 +443,7 @@ func (t *Triggerer) getTriggersByType() (byType map[rune]map[string]string, err 
 
 	byType = make(map[rune]map[string]string)
 	// Initialize maps for all trigger types
-	for triggerTypeID, _ := range triggerTypes {
+	for triggerTypeID := range triggerTypes {
 		byType[triggerTypeID] = make(map[string]string)
 	}
 

--- a/store/leveldb_test.go
+++ b/store/leveldb_test.go
@@ -95,7 +95,7 @@ func TestDeleteString(t *testing.T) {
 	err = bs.DeleteString("testKey")
 	assert.Nil(t, err)
 
-	v, err = bs.GetString("testKey")
+	_, err = bs.GetString("testKey")
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "not found")
 	}
@@ -123,7 +123,7 @@ func TestDeleteAsBytes(t *testing.T) {
 	err = bs.Delete([]byte("testKey"))
 	assert.Nil(t, err)
 
-	v, err = bs.Get([]byte("testKey"))
+	_, err = bs.Get([]byte("testKey"))
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "not found")
 	}

--- a/test/assertaction/assertaction.go
+++ b/test/assertaction/assertaction.go
@@ -20,9 +20,9 @@ func MatchesAndAnswers(t *testing.T, action slackscot.ActionDefinition, m *slack
 		a := action.Answer(m)
 
 		return validateAnswer(t, a)
-	} else {
-		return false
 	}
+
+	return false
 }
 
 // MatchesAndEmojiReacts asserts that the action.Match is true and validates that expected emojis reactions are added to the message
@@ -39,9 +39,9 @@ func MatchesAndEmojiReacts(t *testing.T, plugin *slackscot.Plugin, action slacks
 		return assert.Equalf(t, m.Channel, ec.Channel, "Expected emoji reactions on the same channel as the triggering message [%s] but was [%s]", m.Channel, ec.Channel) &&
 			assert.Equalf(t, m.Timestamp, ec.Timestamp, "Expected emoji reactions on the same timestamp as the triggering message [%s] but was [%s]", m.Timestamp, ec.Timestamp) &&
 			assert.ElementsMatchf(t, expectedEmojis, ec.Emojis, "Expected emoji reactions [%s] but got [%s]", expectedEmojis, ec.Emojis)
-	} else {
-		return false
 	}
+
+	return false
 }
 
 // NotMatch asserts that action.Match is false

--- a/test/assertanswer/assertanswer.go
+++ b/test/assertanswer/assertanswer.go
@@ -17,18 +17,16 @@ type ResolvedAnswerOption struct {
 func HasText(t *testing.T, answer *slackscot.Answer, text string) bool {
 	if assert.NotNil(t, answer) {
 		return assert.Equalf(t, text, answer.Text, "Answer text expected to be [%s] but was [%s]", text, answer.Text)
-	} else {
-		return false
 	}
+	return false
 }
 
 // HasText asserts that the answer's text contains the expected subString
 func HasTextContaining(t *testing.T, answer *slackscot.Answer, subString string) bool {
 	if assert.NotNil(t, answer) {
 		return assert.Containsf(t, answer.Text, subString, "Answer expected to have text containing [%s] but its text [%s] didn't", subString, answer.Text)
-	} else {
-		return false
 	}
+	return false
 }
 
 // HasOptions asserts that the answer's options contains the expected configuration key/values
@@ -36,9 +34,8 @@ func HasOptions(t *testing.T, answer *slackscot.Answer, options ...ResolvedAnswe
 	if assert.NotNil(t, answer) {
 		ropts := convertConfigsToResolvedAnswerOptions(slackscot.ApplyAnswerOpts(answer.Options...))
 		return assert.ElementsMatchf(t, options, ropts, "Answer options expected %s but were %s", options, ropts)
-	} else {
-		return false
 	}
+	return false
 }
 
 // convertConfigsToResolvedAnswerOptions converts a map[string]string of answer options to an array

--- a/test/assertplugin/assertplugin.go
+++ b/test/assertplugin/assertplugin.go
@@ -59,18 +59,20 @@ type ResultValidator func(t *testing.T, answers []*slackscot.Answer, emojis []st
 func (a *Asserter) AnswersAndReacts(t *testing.T, p *slackscot.Plugin, m *slack.Msg, validate ResultValidator) (valid bool) {
 	ec := test.NewEmojiReactionCaptor()
 	p.EmojiReactor = ec
-
-	// Attach asserter logger or use a default one that logs to a string builder
-	if a.logger != nil {
-		p.Logger = slackscot.NewSLogger(a.logger, true)
-	} else {
-		var b strings.Builder
-		p.Logger = slackscot.NewSLogger(log.New(&b, "", 0), true)
-	}
+	p.Logger = slackscot.NewSLogger(getLogger(a), true)
 
 	answers := a.driveActions(p, m)
 
 	return validate(t, answers, ec.Emojis)
+}
+
+func getLogger(a *Asserter) (logger *log.Logger) {
+	if a.logger != nil {
+		return a.logger
+	}
+
+	var b strings.Builder
+	return log.New(&b, "", 0)
 }
 
 func (a *Asserter) driveActions(p *slackscot.Plugin, m *slack.Msg) (answers []*slackscot.Answer) {

--- a/test/assertplugin/assertplugin_test.go
+++ b/test/assertplugin/assertplugin_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/alexandre-normand/slackscot/test/assertplugin"
 	"github.com/nlopes/slack"
 	"github.com/stretchr/testify/assert"
+	"log"
 	"strings"
 	"testing"
 )
@@ -25,7 +26,7 @@ func newLittleTester() (mlt *myLittleTester) {
 		},
 		Usage:       "",
 		Description: "",
-		Answer:      findChicakee,
+		Answer:      mlt.findChicakee,
 	}}
 
 	mlt.HearActions = []slackscot.ActionDefinition{
@@ -62,7 +63,8 @@ func newLittleTester() (mlt *myLittleTester) {
 	return mlt
 }
 
-func findChicakee(m *slackscot.IncomingMessage) *slackscot.Answer {
+func (mlt *myLittleTester) findChicakee(m *slackscot.IncomingMessage) *slackscot.Answer {
+	mlt.Logger.Debugf("a debug statement")
 	return &slackscot.Answer{Text: "👀 in the 🌲"}
 }
 
@@ -97,6 +99,19 @@ func TestCommandResultValid(t *testing.T) {
 
 	assert.Equal(t, true, assertplugin.AnswersAndReacts(mockT, &myLittleTester.Plugin, &slack.Msg{Text: "<@bot> tell me where the black-capped chickadee is"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "👀 in the 🌲")
+	}))
+}
+
+func TestLoggerAttached(t *testing.T) {
+	mockT := new(testing.T)
+
+	var b strings.Builder
+	logger := log.New(&b, "", 0)
+	assertplugin := assertplugin.New("bot", assertplugin.OptionLog(logger))
+	myLittleTester := newLittleTester()
+
+	assert.Equal(t, true, assertplugin.AnswersAndReacts(mockT, &myLittleTester.Plugin, &slack.Msg{Text: "<@bot> tell me where the black-capped chickadee is"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "👀 in the 🌲") && assert.Equal(t, "a debug statement\n", b.String())
 	}))
 }
 

--- a/test/emojireactioncaptor.go
+++ b/test/emojireactioncaptor.go
@@ -14,6 +14,7 @@ type EmojiReactionCaptor struct {
 	Emojis    []string
 }
 
+// AddReaction adds an emoji reaction with the given named emoji to the given item
 func (e *EmojiReactionCaptor) AddReaction(name string, item slack.ItemRef) error {
 	if e.Channel == "" {
 		e.Channel = item.Channel

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.9.2"
+	VERSION = "1.9.3"
 )


### PR DESCRIPTION
## What is this about
Finger quoting used to match on words only but irregardless of the context (that is something like `/hello/` could be a match. While preserving the same word length requirement, this is now implemented via a `regexp` that won't take words that aren't preceded by the start of a line or a space. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass