### PR TITLE
Ignore Messages with SubType message_replied

### DIFF
--- a/slackscot.go
+++ b/slackscot.go
@@ -420,7 +420,7 @@ func (s *Slackscot) processMessageEvent(driver chatDriver, msgEvent *slack.Messa
 		} else {
 			if msgEvent.SubType == "message_changed" {
 				s.processUpdatedMessage(driver, msgEvent, slackMessageID)
-			} else {
+			} else if msgEvent.SubType != "message_replied" {
 				s.processNewMessage(driver, msgEvent, slackMessageID)
 			}
 		}
@@ -604,7 +604,7 @@ func (s *Slackscot) routeMessage(m *slack.Msg) (responses []*OutgoingMessage) {
 
 	responses = make([]*OutgoingMessage, 0)
 
-	// Ignore messages send by "us"
+	// Ignore messages_replied and messages send by "us"
 	if m.User == s.selfID || m.BotID == s.selfID {
 		s.log.Debugf("Ignoring message from user [%s] because that's \"us\" [%s]", m.User, s.selfID)
 

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -126,6 +126,12 @@ func optionChangedMessage(text string, user string, originalTs string) func(e *s
 	}
 }
 
+func optionMessageReplied() func(e *slack.MessageEvent) {
+	return func(e *slack.MessageEvent) {
+		e.SubType = "message_replied"
+	}
+}
+
 func optionDeletedMessage(channelID string, timestamp string) func(e *slack.MessageEvent) {
 	return func(e *slack.MessageEvent) {
 		e.SubType = "message_deleted"
@@ -234,6 +240,17 @@ func TestHandleIncomingMessageTriggeringResponse(t *testing.T) {
 	assert.Equal(t, 0, len(updatedMsgs))
 	assert.Equal(t, 0, len(deletedMsgs))
 	assert.Equal(t, 0, len(rtmSender.rtmMsgs))
+}
+
+func TestIgnoreIncomingMessageReplied(t *testing.T) {
+	sentMsgs, updatedMsgs, deletedMsgs, rtmSender, _ := runSlackscotWithIncomingEventsWithLogs(t, nil, newTestPlugin(), []slack.RTMEvent{
+		newRTMMessageEvent(newMessageEvent("Cgeneral", "blue jays", "Alphonse", timestamp1, optionMessageReplied())),
+	})
+
+	assert.Empty(t, sentMsgs)
+	assert.Empty(t, updatedMsgs)
+	assert.Empty(t, deletedMsgs)
+	assert.Empty(t, rtmSender.rtmMsgs)
 }
 
 func TestIgnoreReplyToMessage(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.9.3"
+	VERSION = "1.9.4"
 )


### PR DESCRIPTION
## What is this about
Fixes a bug manifesting itself when triggering commands in direct messages. A long output like `help` would cause a `message_replied` message to come in afterwards and this would cause the default command to run (since that was a direct message). Messages with the  `message_replied` subtype are now ignored.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass