### PR TITLE
Unhide List Trigger Commands From Triggerer

### DIFF
--- a/plugins/triggerer.go
+++ b/plugins/triggerer.go
@@ -141,7 +141,7 @@ func pluginCommands(t *Triggerer) []slackscot.ActionDefinition {
 			Answer:      t.deleteStandardTrigger,
 		},
 		{
-			Hidden: true,
+			Hidden: false,
 			Match: func(m *slackscot.IncomingMessage) bool {
 				return strings.HasPrefix(m.NormalizedText, "list triggers")
 			},
@@ -164,7 +164,7 @@ func pluginCommands(t *Triggerer) []slackscot.ActionDefinition {
 			Answer:      t.deleteEmojiTrigger,
 		},
 		{
-			Hidden: true,
+			Hidden: false,
 			Match: func(m *slackscot.IncomingMessage) bool {
 				return strings.HasPrefix(m.NormalizedText, "list emoji triggers")
 			},

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.9.4"
+	VERSION = "1.9.5"
 )


### PR DESCRIPTION
## What is this about
`list triggers` and `list emoji triggers` were set to `hidden` but they shouldn't have. This fixes it. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass