### PR TITLE
Improve Trigger List Formatting with a Bigger Round Bullet Symbol

### DIFF
--- a/plugins/triggerer.go
+++ b/plugins/triggerer.go
@@ -472,7 +472,7 @@ func formatTriggers(triggers map[string]string, render elementRenderer) string {
 	bufw := bufio.NewWriter(&b)
 	w.Init(bufw, 5, 0, 1, ' ', 0)
 	for _, trigger := range keys {
-		fmt.Fprintf(w, "\t∙ %s\n", render(trigger, triggers[trigger]))
+		fmt.Fprintf(w, "\t• %s\n", render(trigger, triggers[trigger]))
 	}
 	fmt.Fprintf(w, "\n")
 

--- a/plugins/triggerer_test.go
+++ b/plugins/triggerer_test.go
@@ -328,7 +328,7 @@ func TestListTriggers(t *testing.T) {
 	}) {
 		// List triggers
 		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> list triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the current triggers: \n     ∙ `deal with it` => `http://dealwithit.gif`\n     ∙ `suddenly`     => `https://suddenly.gif`\n\n") &&
+			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the current triggers: \n     • `deal with it` => `http://dealwithit.gif`\n     • `suddenly`     => `https://suddenly.gif`\n\n") &&
 				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 		})
 	}
@@ -347,7 +347,7 @@ func TestListEmojiTriggers(t *testing.T) {
 	}) {
 		// List triggers
 		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> list emoji triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the current emoji triggers: \n     ∙ `deal with it` => :sunglasses:\n     ∙ `suddenly`     => :scream:, :ghost:\n\n") &&
+			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the current emoji triggers: \n     • `deal with it` => :sunglasses:\n     • `suddenly`     => :scream:, :ghost:\n\n") &&
 				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 		})
 	}

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.9.5"
+	VERSION = "1.9.6"
 )


### PR DESCRIPTION
## What is this about
The round bullet I had picked was just wrong. It looks like a speck of dust in `slack`.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass