### PR TITLE
Make Triggerer React Insensitively on Registerer Triggers

### DIFF
--- a/plugins/triggerer.go
+++ b/plugins/triggerer.go
@@ -215,7 +215,7 @@ func (t *Triggerer) matchTriggers(m *slackscot.IncomingMessage) bool {
 
 	for _, triggers := range triggersByType {
 		for trigger := range triggers {
-			if strings.Contains(m.NormalizedText, trigger) {
+			if strings.Contains(strings.ToUpper(m.NormalizedText), strings.ToUpper(trigger)) {
 				return true
 			}
 		}
@@ -240,7 +240,7 @@ func (t *Triggerer) reactOnTriggers(m *slackscot.IncomingMessage) *slackscot.Ans
 // reactOnStandardTriggers returns a reaction string if it finds a trigger match. Note that only at most one standard trigger can match
 func (t *Triggerer) reactOnStandardTriggers(m *slackscot.IncomingMessage, standardTriggers map[string]string) *slackscot.Answer {
 	for trigger, reaction := range standardTriggers {
-		if strings.Contains(m.NormalizedText, trigger) {
+		if strings.Contains(strings.ToUpper(m.NormalizedText), strings.ToUpper(trigger)) {
 			return &slackscot.Answer{Text: reaction}
 		}
 	}
@@ -251,7 +251,7 @@ func (t *Triggerer) reactOnStandardTriggers(m *slackscot.IncomingMessage, standa
 // reactOnEmojiTriggers adds emoji reactions matching emoji triggers, as appropriate
 func (t *Triggerer) reactOnEmojiTriggers(m *slackscot.IncomingMessage, emojiTriggers map[string]string) {
 	for trigger, reaction := range emojiTriggers {
-		if strings.Contains(m.NormalizedText, trigger) {
+		if strings.Contains(strings.ToUpper(m.NormalizedText), strings.ToUpper(trigger)) {
 			for _, emoji := range parseEmojiList(reaction) {
 				t.EmojiReactor.AddReaction(emoji, slack.NewRefToMessage(m.Channel, m.Timestamp))
 			}

--- a/plugins/triggerer_test.go
+++ b/plugins/triggerer_test.go
@@ -79,6 +79,10 @@ func TestRegisterNewTrigger(t *testing.T) {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://dealwithit.gif") && assertanswer.HasOptions(t, answers[0])
 		})
 
+		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://dealwithit.gif") && assertanswer.HasOptions(t, answers[0])
+		})
+
 		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "don't tell me to deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://dealwithit.gif") && assertanswer.HasOptions(t, answers[0])
 		})
@@ -98,7 +102,12 @@ func TestRegisterNewEmojiTrigger(t *testing.T) {
 		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with nothing"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, emojis) && assert.Empty(t, answers)
 		})
+
 		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+			return assert.Empty(t, answers) && assert.Contains(t, emojis, "boom", "cat")
+		})
+
+		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, answers) && assert.Contains(t, emojis, "boom", "cat")
 		})
 	}

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.9.6"
+	VERSION = "1.9.7"
 )


### PR DESCRIPTION
## What is this about
This makes registerer triggers be case-insensitive.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass