### PR TITLE
Prevent Karma to Register on SQL and diff Outputs

### DIFF
--- a/plugins/karma.go
+++ b/plugins/karma.go
@@ -24,7 +24,7 @@ const (
 	KarmaPluginName = "karma"
 )
 
-var karmaRegex = regexp.MustCompile("\\s*<?(@?[\\w-']+)>?(\\+\\+|\\-\\-).*")
+var karmaRegex = regexp.MustCompile("(?:\\A|\\W)<?(@?[\\w']+-?[\\w']+)>?(\\+{2}|\\-{2}).*")
 var topKarmaRegexp = regexp.MustCompile("(?i)(karma top)+ (\\d+).*")
 var worstKarmaRegexp = regexp.MustCompile("(?i)(karma worst)+ (\\d+).*")
 

--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -52,7 +52,11 @@ func TestKarmaMatchesAndAnswers(t *testing.T) {
 		{"<@U21355>++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 6)"}},
 		{"karma top 1", map[string]bool{"h[0]": false, "c[0]": true, "c[1]": false}, map[string]string{"c[0]": "Here are the top 1 things: \n```6    Bernard Tremblay\n```\n"}},
 		{"don't++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`don't` just gained a level (`don't`: 1)"}},
-		{"under-the-bridge++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`under-the-bridge` just gained a level (`under-the-bridge`: 1)"}},
+		{"under-the-bridge++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`the-bridge` just gained a level (`the-bridge`: 1)"}},
+		{"Jean-Michel++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`Jean-Michel` just gained a level (`Jean-Michel`: 1)"}},
+		{"+----------+", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": false}, map[string]string{}},
+		{"---", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": false}, map[string]string{}},
+		{"+++", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": false}, map[string]string{}},
 	}
 
 	// Create a temp file that will serve as an invalid storage path

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.9.7"
+	VERSION = "1.9.8"
 )


### PR DESCRIPTION
## What is this about
This is for @doug-descombaz. Some tweaks to the `karma` regex to avoid registering `karma` on `sql` or `diff` outputs. The tradeoff (surprise?!) is that hyphenated words won't be captured like they used to. So `under-the-bridge++` would now be captured as `the-bridge++`. 

Wait? Did you see? How come I'm still capturing one hyphen? 

I thought it'd be sad to lose the ability to do composed first names like `s-m++` so I made it a special case. 

🙇 You're welcome.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass