### PR TITLE
Add Google Cloud Implementation of StringStorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ your ambitious dreams (if you dreams include this sort of thing).
     A default file-based implementation is provided backed by
     [leveldb](https://github.com/syndtr/goleveldb)
 
+*   Implementation of `StringStorer` backed by
+    [Google Cloud Datastore](https://cloud.google.com/datastore/docs/reference/libraries).
+    See [datastoredb](https://godoc.org/github.com/alexandre-normand/slackscot/store/datastoredb) 
+    for documentation, usage and example.
+
 *   Support for various configuration sources/formats via 
     [viper](https://github.com/spf13/viper)
 
@@ -90,9 +95,10 @@ your ambitious dreams (if you dreams include this sort of thing).
 *   *Experimental and subject to change*: 
     Testing functions to help validate plugin action behavior (see example in 
     [triggerer_test.go](plugins/triggerer_test.go)). Testing functions
-    are found in [assertplugin](test/assertplugin), 
-    [assertaction](test/assertaction) and 
-    [assertanswer](test/assertanswer)
+    are found in 
+    [assertplugin](https://godoc.org/github.com/alexandre-normand/slackscot/test/assertplugin), 
+    [assertaction](https://godoc.org/github.com/alexandre-normand/slackscot/test/assertaction) and 
+    [assertanswer](https://godoc.org/github.com/alexandre-normand/slackscot/test/assertanswer)
 
 *   Built-in `help` plugin supporting a decently formatted help message
     as a command listing all plugins' actions. If you'd like some actions 

--- a/store/datastoredb/datastoredb.go
+++ b/store/datastoredb/datastoredb.go
@@ -1,0 +1,145 @@
+package datastoredb
+
+import (
+	"cloud.google.com/go/datastore"
+	"context"
+	"google.golang.org/api/option"
+)
+
+/*
+Package databasedb provides an implementation of github.com/alexandre-normand/slackscot/store's StringStorer interface
+backed by the Google Cloud Datastore.
+
+
+Requirements for the Google Cloud Datastore integration:
+  - A valid project id with datastore mode enabled
+  - Google Cloud Credentials (typically in the form of a json file with credentials from https://console.cloud.google.com/apis/credentials/serviceaccountkey)
+
+Example code:
+
+	import (
+		"github.com/alexandre-normand/slackscot/store/datastoredb"
+		"google.golang.org/api/option"
+	)
+
+	func main() {
+		// The first argument is going to be this instance's namespace so the plugin name is a good candidate.
+		// The second argument is the gcloud project id which is what you'll have created with your gcloud service account
+		// The third argument are client options which are most useful for providing credentials either in the form of a pre-parsed json file or
+		// most commonly, the path to a json credentials file
+		karmaStorer, err := datastoredb.New(plugins.KarmaPluginName, "youppi", option.WithCredentialsFile(*gcloudCredentialsFile))
+		if err != nil {
+			log.Fatalf("Opening [%s] db failed: %s", plugins.KarmaPluginName, err.Error())
+		}
+		defer karmaStorer.Close()
+
+		// Do something with the database
+		karma := plugins.NewKarma(karmaStorer)}
+
+		// Run your instance
+		...
+	}
+*/
+
+// DatastoreDB implements the slackscot StringStorer interface. It maps
+// the given name (usually a plugin name) to the datastore entity Kind
+// to isolate data between different plugins
+type DatastoreDB struct {
+	*datastore.Client
+	kind string
+}
+
+// EntryValue represents an entity/entry value mapped to a datastore key
+type EntryValue struct {
+	Value string `datastore:",noindex"`
+}
+
+// NewDatastoreDB returns a new instance of DatastoreDB for the given name (which maps to the datastore entity "Kind" and can
+// be thought of as the namespace). This function also requires a gcloudProjectID as well as at least one option to provide gcloud client credentials
+func NewDatastoreDB(name string, gcloudProjectID string, gcloudClientOpts ...option.ClientOption) (dsdb *DatastoreDB, err error) {
+	ctx := context.Background()
+	client, err := datastore.NewClient(ctx, gcloudProjectID, gcloudClientOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	dsdb = new(DatastoreDB)
+	dsdb.Client = client
+	dsdb.kind = name
+
+	err = dsdb.testDB()
+	if err = dsdb.testDB(); err != nil {
+		dsdb.Close()
+		return nil, err
+	}
+
+	return dsdb, nil
+}
+
+// testDB makes a lightweight call to the datastore to validate connectivity and credentials
+func (dsdb *DatastoreDB) testDB() (err error) {
+	_, err = dsdb.GetString("testConnectivity")
+
+	if err != nil && err != datastore.ErrNoSuchEntity {
+		return err
+	}
+
+	return nil
+}
+
+// GetString returns the value associated to a given key. If the value is not
+// found or an error occured, the zero-value string is returned along with
+// the error
+func (dsdb *DatastoreDB) GetString(key string) (value string, err error) {
+	ctx := context.Background()
+
+	var e EntryValue
+	k := datastore.NameKey(dsdb.kind, key, nil)
+	if err := dsdb.Get(ctx, k, &e); err != nil {
+		return "", err
+	}
+
+	return e.Value, nil
+}
+
+// PutString stores the key/value to the database
+func (dsdb *DatastoreDB) PutString(key string, value string) (err error) {
+	ctx := context.Background()
+	k := datastore.NameKey(dsdb.kind, key, nil)
+
+	_, err = dsdb.Put(ctx, k, &EntryValue{Value: value})
+	return err
+}
+
+// DeleteString deletes the entry for the given key. If the entry is not found
+// an error is returned
+func (dsdb *DatastoreDB) DeleteString(key string) (err error) {
+	ctx := context.Background()
+	k := datastore.NameKey(dsdb.kind, key, nil)
+
+	return dsdb.Delete(ctx, k)
+}
+
+// Scan returns all key/values from the database
+func (dsdb *DatastoreDB) Scan() (entries map[string]string, err error) {
+	entries = make(map[string]string)
+
+	ctx := context.Background()
+	var vals []*EntryValue
+
+	keys, err := dsdb.GetAll(ctx, datastore.NewQuery(dsdb.kind), &vals)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, key := range keys {
+		entries[key.Name] = vals[i].Value
+	}
+
+	return entries, nil
+}
+
+// Close closes the underlying datastore client
+func (dsdb *DatastoreDB) Close() (err error) {
+	return dsdb.Client.Close()
+}

--- a/test/assertplugin/assertplugin.go
+++ b/test/assertplugin/assertplugin.go
@@ -1,3 +1,6 @@
+// Package assertplugin provides testing functions to validate a plugin's overall functionality.
+// This package is designed to play well but not require the assertanswer package for validation
+// of answers
 package assertplugin
 
 import (

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.9.8"
+	VERSION = "1.10.0"
 )


### PR DESCRIPTION
## What is this about
@s-machina: Here's a `datastore` implementation of the `StringStorer` interface. I tried to include a good usage example and documentation in the package but I can summarize a few things here:

*   The `name` passed to `datastoredb.New` maps to the datastore entity `kind`. Basically, this is how we `namespace` things and isolate plugins from each other. That way, they each get their own view even though you see everything for a project when you look at the Datastore web UI.  
*   The `gcloudProjectID` and the `gcloud credentials` (usually a credentials `json` file downloaded from https://console.cloud.google.com/apis/credentials/serviceaccountkey) are the only other things needed. 

I tried this with me personal account and `youppi` and it worked fine. Unfortunately, testing this would be difficult so there are none. Thankfully, it's a pretty thin wrapper on top of the `datastore` API so it's probably okay. I'm just concerned that `code climate` won't be happy with the coverage drop 😬 .

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass