### PR TITLE
Remove Bad Import String in store/datastoredb/doc.go

### DIFF
--- a/store/datastoredb/doc.go
+++ b/store/datastoredb/doc.go
@@ -32,4 +32,4 @@ Example code:
 		...
 	}
 */
-package datastoredb // import "github.com/alexandre-normand/datastoredb"
+package datastoredb


### PR DESCRIPTION
## What is this about
This comment with the wrong import string made `godoc` not render the package doc at the expected URL. Removing it and letting it find the import on its own seems like a better idea. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass