### PR TITLE
Add inmemorydb Wrapping StringStorer to Keep Data in Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,14 @@ your ambitious dreams (if you dreams include this sort of thing).
 
 *   Implementation of `StringStorer` backed by
     [Google Cloud Datastore](https://cloud.google.com/datastore/docs/reference/libraries).
-    See [datastoredb](https://godoc.org/github.com/alexandre-normand/slackscot/store/datastoredb) 
+    See [datastoredb's godoc](https://godoc.org/github.com/alexandre-normand/slackscot/store/datastoredb) 
+    for documentation, usage and example.
+
+*   In-memory implementation of `StringStorer` wrapping any `StringStorer` implementation
+    to offer low-latency and potentially cost-saving storage implementation well-suited for
+    small datasets. Plays well with cloud storage like the 
+    [datastoredb]((https://godoc.org/github.com/alexandre-normand/slackscot/store/datastoredb) 
+    See [inmemorydb's godoc](https://godoc.org/github.com/alexandre-normand/slackscot/store/inmemorydb) 
     for documentation, usage and example.
 
 *   Support for various configuration sources/formats via 

--- a/store/datastoredb/doc.go
+++ b/store/datastoredb/doc.go
@@ -5,7 +5,8 @@ backed by the Google Cloud Datastore.
 
 Requirements for the Google Cloud Datastore integration:
   - A valid project id with datastore mode enabled
-  - Google Cloud Credentials (typically in the form of a json file with credentials from https://console.cloud.google.com/apis/credentials/serviceaccountkey)
+  - Google Cloud Credentials (typically in the form of a json file
+    with credentials from https://console.cloud.google.com/apis/credentials/serviceaccountkey)
 
 Example code:
 

--- a/store/inmemorydb/doc.go
+++ b/store/inmemorydb/doc.go
@@ -1,0 +1,46 @@
+/*
+Package inmemorydb provides an implementation of github.com/alexandre-normand/slackscot/store's StringStorer interface
+as an in-memory data store relying on a wrapping StringStorer for actual persistence.
+
+The main use-case for the inmemorydb is to shield the real StringStorer implementation from receiving too many calls
+as plugins may very well query their StringStorer on every message to evaluate for a match or answer. Of course,
+using this also allows the slackscot instance to offer lower latency at the expense of increased memory usage.
+
+Most plugin databases are small and this is therefore a good idea to use inmemorydb but if your instance uses
+plugins storing a large number of rows, consider using a different storage interface than the slackscot StringStorer
+or skipping the usage of the inmemorydb.
+
+Requirements for the Google Cloud Datastore integration:
+  - A valid project id with datastore mode enabled
+  - Google Cloud Credentials (typically in the form of a json file with credentials from https://console.cloud.google.com/apis/credentials/serviceaccountkey)
+
+Example code:
+
+	import (
+		"github.com/alexandre-normand/slackscot/store/datastoredb"
+		"github.com/alexandre-normand/slackscot/store/inmemorydb"
+		"google.golang.org/api/option"
+	)
+
+	func main() {
+		// Create your persistent storer first
+		persistentStorer, err := datastoredb.New(plugins.KarmaPluginName, "youppi", option.WithCredentialsFile(*gcloudCredentialsFile))
+		if err != nil {
+			log.Fatalf("Opening [%s] db failed: %s", plugins.KarmaPluginName, err.Error())
+		}
+		defer persistentStorer.Close()
+
+		// Create the inmemorydb
+		karmaStorer, err := inmemorydb.New(persistenStorer)
+		if err != nil {
+			log.Fatalf("Opening creating in-memory db wrapper: %s", err.Error())
+		}
+
+		// Do something with the database
+		karma := plugins.NewKarma(karmaStorer)}
+
+		// Run your instance
+		...
+	}
+*/
+package inmemorydb

--- a/store/inmemorydb/inmemorydb.go
+++ b/store/inmemorydb/inmemorydb.go
@@ -1,0 +1,83 @@
+package inmemorydb
+
+import (
+	"fmt"
+	"github.com/alexandre-normand/slackscot/store"
+)
+
+// InMemoryDB implements the slackscot StringStorer interface and keeps
+// a copy of everything in memory while writing through puts and deletes
+// to the wrapped (persistent) StringStorer
+type InMemoryDB struct {
+	persistentStorer store.StringStorer
+	data             map[string]string
+}
+
+// New returns a new instance of InMemoryDB wrapping the persistent StringStorer.
+// Note that instantiation might have some latency induced by the initial scan to load
+// the current database content from the persistentStorer in memory
+func New(storer store.StringStorer) (imdb *InMemoryDB, err error) {
+	imdb = new(InMemoryDB)
+	imdb.persistentStorer = storer
+
+	imdb.data, err = imdb.persistentStorer.Scan()
+	if err != nil {
+		return nil, err
+	}
+
+	return imdb, nil
+}
+
+// GetString returns the value associated to a given key. If the value is not
+// found or an error occured, the zero-value string is returned along with
+// the error
+func (imdb *InMemoryDB) GetString(key string) (value string, err error) {
+	v, ok := imdb.data[key]
+	if !ok {
+		return "", fmt.Errorf("%s not found", key)
+	}
+
+	return v, nil
+}
+
+// PutString stores the key/value to the database. The key/value is persisted to
+// persistent storage and also kept in memory
+func (imdb *InMemoryDB) PutString(key string, value string) (err error) {
+	err = imdb.persistentStorer.PutString(key, value)
+
+	if err != nil {
+		return err
+	}
+
+	imdb.data[key] = value
+	return nil
+}
+
+// DeleteString deletes the entry for the given key. This is propagated to the
+// persistent storage first and then deleted from memory
+func (imdb *InMemoryDB) DeleteString(key string) (err error) {
+	err = imdb.persistentStorer.DeleteString(key)
+	if err != nil {
+		return err
+	}
+
+	delete(imdb.data, key)
+	return nil
+}
+
+// Scan returns all key/values from the database. This one returns a copy of the in-memory
+// copy without querying the persistent storer.
+func (imdb *InMemoryDB) Scan() (entries map[string]string, err error) {
+	entries = make(map[string]string)
+
+	for k, v := range imdb.data {
+		entries[k] = v
+	}
+
+	return entries, nil
+}
+
+// Close closes the underlying storer
+func (imdb *InMemoryDB) Close() (err error) {
+	return imdb.persistentStorer.Close()
+}

--- a/store/inmemorydb/inmemorydb_test.go
+++ b/store/inmemorydb/inmemorydb_test.go
@@ -1,0 +1,262 @@
+package inmemorydb_test
+
+import (
+	"fmt"
+	"github.com/alexandre-normand/slackscot/store/inmemorydb"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type mockStorer struct {
+	data            map[string]string
+	errorOnNextCall bool
+	closed          bool
+}
+
+func newMockStorer(existingData map[string]string) (ms *mockStorer) {
+	ms = new(mockStorer)
+	ms.data = existingData
+	return ms
+}
+
+func (ms *mockStorer) GetString(key string) (value string, err error) {
+	if ms.errorOnNextCall {
+		return "", fmt.Errorf("error with persistent db")
+	}
+
+	v, ok := ms.data[key]
+	if !ok {
+		return "", fmt.Errorf("%s not found", key)
+	}
+
+	return v, nil
+}
+
+func (ms *mockStorer) PutString(key string, value string) (err error) {
+	if ms.errorOnNextCall {
+		return fmt.Errorf("error with persistent db")
+	}
+
+	ms.data[key] = value
+	return nil
+}
+
+func (ms *mockStorer) DeleteString(key string) (err error) {
+	if ms.errorOnNextCall {
+		return fmt.Errorf("error with persistent db")
+	}
+
+	delete(ms.data, key)
+	return nil
+}
+
+func (ms *mockStorer) Scan() (entries map[string]string, err error) {
+	if ms.errorOnNextCall {
+		return nil, fmt.Errorf("error with persistent db")
+	}
+
+	entries = make(map[string]string)
+
+	for k, v := range ms.data {
+		entries[k] = v
+	}
+
+	return entries, nil
+}
+
+func (ms *mockStorer) Close() (err error) {
+	if ms.errorOnNextCall {
+		return fmt.Errorf("error with persistent db")
+	}
+
+	ms.closed = true
+	return nil
+}
+
+func TestNewWithErrorLoadingPersistentContent(t *testing.T) {
+	ms := &mockStorer{errorOnNextCall: true}
+
+	_, err := inmemorydb.New(ms)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "error with persistent db")
+	}
+}
+
+func TestGetWithPersistedExistingContent(t *testing.T) {
+	ms := newMockStorer(map[string]string{"key1": "value1", "key2": "value2"})
+
+	imdb, err := inmemorydb.New(ms)
+	if assert.Nil(t, err) {
+		v1, err := imdb.GetString("key1")
+		assert.Nil(t, err)
+		assert.Equal(t, "value1", v1)
+
+		v2, err := imdb.GetString("key2")
+		assert.Nil(t, err)
+		assert.Equal(t, "value2", v2)
+	}
+}
+
+func TestScanExistingContent(t *testing.T) {
+	ms := newMockStorer(map[string]string{"key1": "value1", "key2": "value2"})
+
+	imdb, err := inmemorydb.New(ms)
+	if assert.Nil(t, err) {
+		elements, err := imdb.Scan()
+		// Modify the persistent storer to make sure that the map returned was a copy
+		// and not the reference
+		ms.data["key3"] = "should not be visible in the scan results"
+
+		assert.Nil(t, err)
+		assert.Equal(t, map[string]string{"key1": "value1", "key2": "value2"}, elements)
+	}
+}
+
+func TestUpdateExistingContent(t *testing.T) {
+	ms := newMockStorer(map[string]string{"key1": "value1", "key2": "value2"})
+
+	imdb, err := inmemorydb.New(ms)
+	if assert.Nil(t, err) {
+		err := imdb.PutString("key1", "bird")
+		if assert.Nil(t, err) {
+			imv1, err := imdb.GetString("key1")
+			assert.Nil(t, err)
+			assert.Equal(t, "bird", imv1)
+
+			// Check it's also really persisted to the "persistent" storer
+			msv1, err := ms.GetString("key1")
+			assert.Nil(t, err)
+			assert.Equal(t, "bird", msv1)
+		}
+	}
+}
+
+func TestDeleteExistingContent(t *testing.T) {
+	ms := newMockStorer(map[string]string{"key1": "value1", "key2": "value2"})
+
+	imdb, err := inmemorydb.New(ms)
+	if assert.Nil(t, err) {
+		err := imdb.DeleteString("key1")
+		if assert.Nil(t, err) {
+			imv1, err := imdb.GetString("key1")
+			assert.NotNil(t, err)
+			assert.Equal(t, "", imv1)
+
+			// Check it's also really deleted from the "persistent" storer
+			msv1, err := ms.GetString("key1")
+			assert.NotNil(t, err)
+			assert.Equal(t, "", msv1)
+		}
+	}
+}
+
+func TestGetOnEmptyStorage(t *testing.T) {
+	ms := &mockStorer{data: make(map[string]string)}
+
+	imdb, err := inmemorydb.New(ms)
+	if assert.Nil(t, err) {
+		v1, err := imdb.GetString("key1")
+		assert.Equal(t, "", v1)
+		assert.EqualError(t, err, "key1 not found")
+	}
+}
+
+func TestScanOnEmptyStorage(t *testing.T) {
+	ms := &mockStorer{data: make(map[string]string)}
+
+	imdb, err := inmemorydb.New(ms)
+	if assert.Nil(t, err) {
+		entries, err := imdb.Scan()
+		assert.Nil(t, err)
+		assert.Empty(t, entries)
+	}
+}
+
+func TestCloseClosesPersistentStorage(t *testing.T) {
+	ms := newMockStorer(map[string]string{})
+
+	imdb, err := inmemorydb.New(ms)
+	if assert.Nil(t, err) {
+		err := imdb.Close()
+
+		assert.Nil(t, err)
+		assert.Equalf(t, true, ms.closed, "Persistent db should be closed but wasn't")
+	}
+}
+
+func TestErrorWithPersistentStorageOnGet(t *testing.T) {
+	ms := newMockStorer(map[string]string{"key1": "value1"})
+
+	imdb, err := inmemorydb.New(ms)
+	if assert.Nil(t, err) {
+		ms.errorOnNextCall = true
+
+		_, err = ms.GetString("key1")
+		// Confirm that the "persistent" storer errors out as instructed
+		if assert.EqualError(t, err, "error with persistent db") {
+			val, err := imdb.GetString("key1")
+			// Validate that the in memory db doesn't interact with the persistent
+			// storer on Get and returns what it has in memory
+			assert.Nil(t, err)
+			assert.Equal(t, "value1", val)
+		}
+	}
+}
+
+func TestErrorWithPersistentStorageOnScan(t *testing.T) {
+	ms := newMockStorer(map[string]string{"key1": "value1"})
+
+	imdb, err := inmemorydb.New(ms)
+	if assert.Nil(t, err) {
+		ms.errorOnNextCall = true
+
+		_, err = ms.Scan()
+		// Confirm that the "persistent" storer errors out as instructed
+		if assert.EqualError(t, err, "error with persistent db") {
+			elements, err := imdb.Scan()
+			// Validate that the in memory db doesn't interact with the persistent
+			// storer on Scan and returns what it has in memory
+			assert.Nil(t, err)
+			assert.Equal(t, map[string]string{"key1": "value1"}, elements)
+		}
+	}
+}
+
+func TestErrorWithPersistentStorageOnPut(t *testing.T) {
+	ms := newMockStorer(map[string]string{})
+
+	imdb, err := inmemorydb.New(ms)
+	if assert.Nil(t, err) {
+		ms.errorOnNextCall = true
+
+		err := imdb.PutString("key1", "value1")
+
+		assert.EqualError(t, err, "error with persistent db")
+	}
+}
+
+func TestErrorWithPersistentStorageOnDelete(t *testing.T) {
+	ms := newMockStorer(map[string]string{})
+
+	imdb, err := inmemorydb.New(ms)
+	if assert.Nil(t, err) {
+		ms.errorOnNextCall = true
+
+		err := imdb.DeleteString("key1")
+
+		assert.EqualError(t, err, "error with persistent db")
+	}
+}
+
+func TestErrorClosingPersistentStorerIsReturned(t *testing.T) {
+	ms := newMockStorer(map[string]string{})
+
+	imdb, err := inmemorydb.New(ms)
+	if assert.Nil(t, err) {
+		ms.errorOnNextCall = true
+
+		err := imdb.Close()
+
+		assert.EqualError(t, err, "error with persistent db")
+	}
+}

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.10.0"
+	VERSION = "1.11.0"
 )


### PR DESCRIPTION
## What is this about
Since the `datastore` might have cost for all the operations and we might be doing a lot of them (some plugins check the db on every message), I thought it would be a good idea to add a `inmemorydb` wrapping any `StringStorer` implementation. This keeps all data in memory so it's more for smaller datasets. Data is loaded from persistent store on creation and then puts/deletes are persisted. The reads are from the in-memory copy. 

Plugins usually have small datasets that will work well with this. If a plugin needed to store huge amounts of data, it would probably make sense to use another storage API anyway. 🤷‍♂️

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass