### PR TITLE
Send Answers to Existing Thread if Triggering Message was sent on Thread

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -5,6 +5,8 @@ const (
 	ThreadedReplyOpt = "threadedReply"
 	// BroadcastOpt is the name of the option indicating a broadcast answer
 	BroadcastOpt = "broadcast"
+	// ThreadTimestamp is the name of the option indicating the explicit timestamp of the thread to reply to
+	ThreadTimestamp = "threadTimestamp"
 )
 
 // AnswerOption defines a function applied to Answers
@@ -14,6 +16,14 @@ type AnswerOption func(sendOpts map[string]string)
 func AnswerInThread() func(sendOpts map[string]string) {
 	return func(sendOpts map[string]string) {
 		sendOpts[ThreadedReplyOpt] = "true"
+	}
+}
+
+// AnswerInExistingThread sets threaded replying with the existing thread timestamp
+func AnswerInExistingThread(threadTimestamp string) func(sendOpts map[string]string) {
+	return func(sendOpts map[string]string) {
+		sendOpts[ThreadedReplyOpt] = "true"
+		sendOpts[ThreadTimestamp] = threadTimestamp
 	}
 }
 

--- a/answer_test.go
+++ b/answer_test.go
@@ -17,6 +17,7 @@ func TestApplyAnswerOptions(t *testing.T) {
 		{"threadedReplyWithBroadcast", []slackscot.AnswerOption{slackscot.AnswerInThreadWithBroadcast()}, map[string]string{slackscot.ThreadedReplyOpt: "true", slackscot.BroadcastOpt: "true"}},
 		{"threadedReplyWithoutBroadcast", []slackscot.AnswerOption{slackscot.AnswerInThreadWithoutBroadcast()}, map[string]string{slackscot.ThreadedReplyOpt: "true", slackscot.BroadcastOpt: "false"}},
 		{"noThreading", []slackscot.AnswerOption{slackscot.AnswerWithoutThreading()}, map[string]string{slackscot.ThreadedReplyOpt: "false"}},
+		{"threadReplyOnExistingThread", []slackscot.AnswerOption{slackscot.AnswerInExistingThread("1000")}, map[string]string{slackscot.ThreadedReplyOpt: "true", slackscot.ThreadTimestamp: "1000"}},
 	}
 
 	for _, tc := range testCases {

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ const (
 	responseCacheSizeDefault        = 5000
 	timeLocationDefault             = "Local"
 	threadedRepliesDefault          = false
-	broadcastThreadedRepliesDefault = true
+	broadcastThreadedRepliesDefault = false
 )
 
 // ReplyBehavior holds flags to define the replying behavior (use threads or not and broadcast replies or not)
@@ -43,9 +43,9 @@ func NewViperWithDefaults() (v *viper.Viper) {
 	v = viper.New()
 	v.SetDefault(DebugKey, debugDefault)
 	v.SetDefault(ResponseCacheSizeKey, responseCacheSizeDefault)
-	v.SetDefault(TimeLocationKey, "Local")
-	v.SetDefault(ThreadedRepliesKey, false)
-	v.SetDefault(BroadcastThreadedRepliesKey, true)
+	v.SetDefault(TimeLocationKey, timeLocationDefault)
+	v.SetDefault(ThreadedRepliesKey, threadedRepliesDefault)
+	v.SetDefault(BroadcastThreadedRepliesKey, broadcastThreadedRepliesDefault)
 
 	return v
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -14,7 +14,7 @@ func TestNewWithDefault(t *testing.T) {
 	assert.Equal(t, 5000, v.GetInt(config.ResponseCacheSizeKey), "%s should be %d", config.ResponseCacheSizeKey, 5000)
 	assert.Equal(t, "Local", v.GetString(config.TimeLocationKey), "%s should be %s", config.TimeLocationKey, "Local")
 	assert.Equal(t, false, v.GetBool(config.ThreadedRepliesKey), "%s should be %t", config.ThreadedRepliesKey, false)
-	assert.Equal(t, true, v.GetBool(config.BroadcastThreadedRepliesKey), "%s should be %t", config.BroadcastThreadedRepliesKey, true)
+	assert.Equal(t, false, v.GetBool(config.BroadcastThreadedRepliesKey), "%s should be %t", config.BroadcastThreadedRepliesKey, false)
 }
 
 func TestGetTimeLocationWithDefault(t *testing.T) {

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.11.0"
+	VERSION = "1.12.0"
 )


### PR DESCRIPTION
## What is this about
This changes the behavior when a triggering message is on a `thread`. Before, the reactions would just show up in the channel and it could look odd for the general channel watchers that weren't also following or participating in the thread. So this changes that and has `answers` go to the `thread` if the message is already on one. It works when I try it live, too.

But the thing is, that's the part of the code I like less and I'm less happy with so I'm leaving this PR here and I'll try to think of a way to clean this up a bit. It's not terrible now but as I gain more experience with this, I feel like it's a good time to stop and see if I can improve this enough that I'd feel good about showing it to strangers (or friends and family). 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass