### PR TITLE
Fix Karma Top/Worst Crashing When No Count Provided

### DIFF
--- a/plugins/karma.go
+++ b/plugins/karma.go
@@ -73,13 +73,13 @@ func matchKarmaRecord(m *slackscot.IncomingMessage) bool {
 // matchKarmaTopReport returns true if the message matches a request for top karma with
 // a message such as "karma top <count>""
 func matchKarmaTopReport(m *slackscot.IncomingMessage) bool {
-	return strings.HasPrefix(m.NormalizedText, "karma top")
+	return topKarmaRegexp.MatchString(m.NormalizedText)
 }
 
 // matchKarmaWorstReport returns true if the message matches a request for the worst karma with
 // a message such as "karma worst <count>""
 func matchKarmaWorstReport(m *slackscot.IncomingMessage) bool {
-	return strings.HasPrefix(m.NormalizedText, "karma worst")
+	return worstKarmaRegexp.MatchString(m.NormalizedText)
 }
 
 // recordKarma records a karma increase or decrease and answers with a message including

--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -57,6 +57,8 @@ func TestKarmaMatchesAndAnswers(t *testing.T) {
 		{"+----------+", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": false}, map[string]string{}},
 		{"---", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": false}, map[string]string{}},
 		{"+++", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": false}, map[string]string{}},
+		{"karma worst", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": false}, map[string]string{}},
+		{"karma top", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": false}, map[string]string{}},
 	}
 
 	// Create a temp file that will serve as an invalid storage path

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.11.0"
+	VERSION = "1.11.1"
 )


### PR DESCRIPTION
## What is this about
Reported this morning by a kind gentleman. I'm not proud of it but the way to check for a `karma top` / `karma worst` match was just stupid. This makes it better and adds tests to prove it.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass