### PR TITLE
Improve Usability of Triggerer

### DIFF
--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.11.1"
+	VERSION = "1.12.0"
 )


### PR DESCRIPTION
## What is this about
- Fix bug with emoji triggers being saved even when the reaction didn't include
  emojis (now slackscot should answer with details explaining no emojis were found)
- Add support for multi-line reactions to standard triggers

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass