### PR TITLE
🚫🧵 Disable Threaded Replies when Communication in Direct Messaging

### DIFF
--- a/slackscot.go
+++ b/slackscot.go
@@ -728,9 +728,12 @@ func reply(replyToMsg *IncomingMessage, answer *Answer) *slack.OutgoingMessage {
 	return newSlackOutgoingMessage(replyToMsg.Channel, fmt.Sprintf("<@%s>: %s", replyToMsg.User, answer.Text))
 }
 
-// directReply sends a reply to a direct message (which is internally a channel id for slack). It is essentially
-// the same as send but it's kept separate for clarity
+// directReply sends a reply to a direct message
 func directReply(replyToMsg *IncomingMessage, answer *Answer) *slack.OutgoingMessage {
+	// Force a non-threaded reply since we're in a direct conversation. Instead of overriding
+	// all existing options, we just add the one to override the threading here
+	answer.Options = append(answer.Options, AnswerWithoutThreading())
+
 	return send(replyToMsg, answer)
 }
 

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -523,7 +523,7 @@ func testHelpTriggering(t *testing.T, v *viper.Viper) {
 		assert.Equal(t, 5, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
-		assert.Equal(t, 5, len(sentMsgs[1].msgOptions))
+		assert.Equal(t, 3, len(sentMsgs[1].msgOptions))
 		assert.Equal(t, "DFromAlphonse", sentMsgs[1].channelID)
 	}
 

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.13.0"
+	VERSION = "1.14.0"
 )


### PR DESCRIPTION
## What is this about
Prevent direct messaging with a `slackscot` to include threaded replies. It's difficult to imagine a use-case for threads in a direct conversation with `slackscot` and, in the meantime, it just feels inappropriate so I think this will be a nice improvement. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass