### PR TITLE
Add file uploader plugin service

### DIFF
--- a/fileuploader.go
+++ b/fileuploader.go
@@ -1,0 +1,60 @@
+package slackscot
+
+import (
+	"github.com/nlopes/slack"
+)
+
+// SlackFileUploader is implemented by any value that has the UploadFile method. slack.Client
+// implements it. The main purpose remains is a slight decoupling of the slack.Client in order
+// for plugins to be able to write cleaner tests more easily.
+type SlackFileUploader interface {
+	// UploadFile uploads a file to slack. For more info in this API, check
+	// https://godoc.org/github.com/nlopes/slack#Client.UploadFile
+	UploadFile(params slack.FileUploadParameters) (file *slack.File, err error)
+}
+
+// FileUploader is implemented by any value that has the UploadFile method. slack.Client *almost*
+// implements it but requires a thin wrapping to do so to handle UploadOption there for
+// added extensibility.
+// The main purpose remains is a slight decoupling of the slack.Client in order for plugins to
+// be able to write cleaner tests more easily.
+type FileUploader interface {
+	// UploadFile uploads a file to slack. For more info in this API, check
+	// https://godoc.org/github.com/nlopes/slack#Client.UploadFile
+	UploadFile(params slack.FileUploadParameters, options ...UploadOption) (file *slack.File, err error)
+}
+
+// UploadOption defines an option on a FileUploadParameters (i.e. upload on thread)
+type UploadOption func(params *slack.FileUploadParameters)
+
+// UploadInExistingThreadOption sets the file upload thread timestamp to an existing thread timestamp if
+// the incoming message triggering this is on an existing thread
+func UploadInThreadOption(m *IncomingMessage) func(params *slack.FileUploadParameters) {
+	return func(p *slack.FileUploadParameters) {
+		if threadTimestamp, inThread := resolveThreadTimestamp(&m.Msg); inThread {
+			p.ThreadTimestamp = threadTimestamp
+		}
+	}
+}
+
+// DefaultFileUploader holds a bare-bone SlackFileUploader
+type DefaultFileUploader struct {
+	slackFileUploader SlackFileUploader
+}
+
+// NewFileUploader returns a new DefaultFileUploader wrapping a FileUploader
+func NewFileUploader(slackFileUploader SlackFileUploader) (fileUploader *DefaultFileUploader) {
+	fileUploader = new(DefaultFileUploader)
+	fileUploader.slackFileUploader = slackFileUploader
+
+	return fileUploader
+}
+
+// UploadFile uploads a file given the slack.FileUploadParameters with the UploadOptions applied to it
+func (fileUploader *DefaultFileUploader) UploadFile(params slack.FileUploadParameters, options ...UploadOption) (file *slack.File, err error) {
+	for _, opt := range options {
+		opt(&params)
+	}
+
+	return fileUploader.slackFileUploader.UploadFile(params)
+}

--- a/fileuploader_test.go
+++ b/fileuploader_test.go
@@ -1,0 +1,39 @@
+package slackscot_test
+
+import (
+	"github.com/alexandre-normand/slackscot"
+	"github.com/alexandre-normand/slackscot/test/capture"
+	"github.com/nlopes/slack"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDefaultUpload(t *testing.T) {
+	fileUploadCaptor := capture.NewFileUploader()
+	uploader := slackscot.NewFileUploader(fileUploadCaptor)
+
+	uploader.UploadFile(slack.FileUploadParameters{Filename: "imageOfABirdInATree.png", Filetype: "image/png", Title: "Look"})
+
+	assert.Len(t, fileUploadCaptor.FileUploads, 1)
+	assert.Equal(t, slack.FileUploadParameters{Filename: "imageOfABirdInATree.png", Filetype: "image/png", Title: "Look"}, fileUploadCaptor.FileUploads[0])
+}
+
+func TestUploadWithExistingTheadOption(t *testing.T) {
+	fileUploadCaptor := capture.NewFileUploader()
+	uploader := slackscot.NewFileUploader(fileUploadCaptor)
+
+	uploader.UploadFile(slack.FileUploadParameters{Filename: "imageOfABirdInATree.png", Filetype: "image/png", Title: "Look"}, slackscot.UploadInThreadOption(&slackscot.IncomingMessage{Msg: slack.Msg{ThreadTimestamp: "100000"}}))
+
+	assert.Len(t, fileUploadCaptor.FileUploads, 1)
+	assert.Equal(t, slack.FileUploadParameters{Filename: "imageOfABirdInATree.png", Filetype: "image/png", Title: "Look", ThreadTimestamp: "100000"}, fileUploadCaptor.FileUploads[0])
+}
+
+func TestUploadWithExistingTheadOptionButNoThreadInMsg(t *testing.T) {
+	fileUploadCaptor := capture.NewFileUploader()
+	uploader := slackscot.NewFileUploader(fileUploadCaptor)
+
+	uploader.UploadFile(slack.FileUploadParameters{Filename: "imageOfABirdInATree.png", Filetype: "image/png", Title: "Look"}, slackscot.UploadInThreadOption(&slackscot.IncomingMessage{Msg: slack.Msg{}}))
+
+	assert.Len(t, fileUploadCaptor.FileUploads, 1)
+	assert.Equal(t, slack.FileUploadParameters{Filename: "imageOfABirdInATree.png", Filetype: "image/png", Title: "Look"}, fileUploadCaptor.FileUploads[0])
+}

--- a/store/datastoredb/datastoredb.go
+++ b/store/datastoredb/datastoredb.go
@@ -53,7 +53,7 @@ func (dsdb *DatastoreDB) testDB() (err error) {
 }
 
 // GetString returns the value associated to a given key. If the value is not
-// found or an error occured, the zero-value string is returned along with
+// found or an error occurred, the zero-value string is returned along with
 // the error
 func (dsdb *DatastoreDB) GetString(key string) (value string, err error) {
 	ctx := context.Background()

--- a/store/datastoredb/doc.go
+++ b/store/datastoredb/doc.go
@@ -1,5 +1,5 @@
 /*
-Package databasedb provides an implementation of github.com/alexandre-normand/slackscot/store's StringStorer interface
+Package datastoredb provides an implementation of github.com/alexandre-normand/slackscot/store's StringStorer interface
 backed by the Google Cloud Datastore.
 
 

--- a/store/inmemorydb/inmemorydb.go
+++ b/store/inmemorydb/inmemorydb.go
@@ -29,7 +29,7 @@ func New(storer store.StringStorer) (imdb *InMemoryDB, err error) {
 }
 
 // GetString returns the value associated to a given key. If the value is not
-// found or an error occured, the zero-value string is returned along with
+// found or an error occurred, the zero-value string is returned along with
 // the error
 func (imdb *InMemoryDB) GetString(key string) (value string, err error) {
 	v, ok := imdb.data[key]

--- a/test/assertaction/assertaction.go
+++ b/test/assertaction/assertaction.go
@@ -3,7 +3,7 @@ package assertaction
 
 import (
 	"github.com/alexandre-normand/slackscot"
-	"github.com/alexandre-normand/slackscot/test"
+	"github.com/alexandre-normand/slackscot/test/capture"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -31,7 +31,7 @@ func MatchesAndEmojiReacts(t *testing.T, plugin *slackscot.Plugin, action slacks
 
 	if assert.Equalf(t, true, isMatch, "Message [%s] expected to match but action.Match returned false", m.NormalizedText) {
 		// Register a new emoji reactor with the plugin
-		ec := test.NewEmojiReactionCaptor()
+		ec := capture.NewEmojiReactor()
 		plugin.EmojiReactor = ec
 
 		action.Answer(m)

--- a/test/assertplugin/assertplugin_test.go
+++ b/test/assertplugin/assertplugin_test.go
@@ -65,6 +65,8 @@ func newLittleTester() (mlt *myLittleTester) {
 
 func (mlt *myLittleTester) findChicakee(m *slackscot.IncomingMessage) *slackscot.Answer {
 	mlt.Logger.Debugf("a debug statement")
+	mlt.FileUploader.UploadFile(slack.FileUploadParameters{Filename: "imageOfABirdInATree.png", Filetype: "image/png", Title: "Look"})
+
 	return &slackscot.Answer{Text: "👀 in the 🌲"}
 }
 
@@ -99,6 +101,16 @@ func TestCommandResultValid(t *testing.T) {
 
 	assert.Equal(t, true, assertplugin.AnswersAndReacts(mockT, &myLittleTester.Plugin, &slack.Msg{Text: "<@bot> tell me where the black-capped chickadee is"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "👀 in the 🌲")
+	}))
+}
+
+func TestFileUploadCapture(t *testing.T) {
+	mockT := new(testing.T)
+	assertplugin := assertplugin.New("bot")
+	myLittleTester := newLittleTester()
+
+	assert.Equal(t, true, assertplugin.AnswersAndReactsWithUploads(mockT, &myLittleTester.Plugin, &slack.Msg{Text: "<@bot> tell me where the black-capped chickadee is"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string, fileUploads []slack.FileUploadParameters) bool {
+		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "👀 in the 🌲") && assert.Len(t, fileUploads, 1) && assert.Equal(t, slack.FileUploadParameters{Filename: "imageOfABirdInATree.png", Filetype: "image/png", Title: "Look"}, fileUploads[0])
 	}))
 }
 

--- a/test/capture/doc.go
+++ b/test/capture/doc.go
@@ -1,0 +1,3 @@
+// Package capture provides dummy implementations of some of the plugin services that
+// capture data fed into them in order to allow validation in tests
+package capture

--- a/test/capture/emojireactioncaptor.go
+++ b/test/capture/emojireactioncaptor.go
@@ -1,4 +1,4 @@
-package test
+package capture
 
 import (
 	"fmt"
@@ -29,8 +29,8 @@ func (e *EmojiReactionCaptor) AddReaction(name string, item slack.ItemRef) error
 	return nil
 }
 
-// NewEmojiReactionCaptor returns a new EmojiReactionCaptor with an initialized emojis array
-func NewEmojiReactionCaptor() (emojiReactionCaptor *EmojiReactionCaptor) {
+// NewEmojiReactor returns a new EmojiReactionCaptor with an initialized emojis array
+func NewEmojiReactor() (emojiReactionCaptor *EmojiReactionCaptor) {
 	emojiReactionCaptor = new(EmojiReactionCaptor)
 	emojiReactionCaptor.Emojis = make([]string, 0)
 

--- a/test/capture/fileuploadcaptor.go
+++ b/test/capture/fileuploadcaptor.go
@@ -1,0 +1,44 @@
+package capture
+
+import (
+	"github.com/nlopes/slack"
+	"strconv"
+	"time"
+)
+
+// FileUploadCaptor captures file uploads recorded by
+// invocations of UploadFile
+type FileUploadCaptor struct {
+	FileUploads []slack.FileUploadParameters
+	currentID   int
+}
+
+// AddReaction adds an emoji reaction with the given named emoji to the given item
+func (f *FileUploadCaptor) UploadFile(params slack.FileUploadParameters) (file *slack.File, err error) {
+	f.FileUploads = append(f.FileUploads, params)
+
+	file = new(slack.File)
+	file.ID = strconv.Itoa(f.currentID)
+	file.Name = params.Filename
+	file.Filetype = params.Filetype
+	file.Title = params.Title
+	file.Created = currentJSONTime()
+
+	// Increment id for the next upload
+	f.currentID = f.currentID + 1
+
+	return file, nil
+}
+
+// NewFileUploader returns a new FileUploadCaptor with an initialized array of FileUploads
+func NewFileUploader() (fileUploadCaptor *FileUploadCaptor) {
+	fileUploadCaptor = new(FileUploadCaptor)
+	fileUploadCaptor.FileUploads = make([]slack.FileUploadParameters, 0)
+
+	return fileUploadCaptor
+}
+
+// currentJSONTime creates a JSONTime value with the current time
+func currentJSONTime() (now slack.JSONTime) {
+	return slack.JSONTime(time.Now().Unix())
+}

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.14.0"
+	VERSION = "1.15.0"
 )


### PR DESCRIPTION
## What is this about
@doug-descombaz You don't have to review this but you might like to since that's the addition of the `FileUploader` plugin service we talked about. This is mostly adding a passthrough access to this [UploadFile](https://godoc.org/github.com/nlopes/slack#Client.UploadFile) api but I think that's the way to do it. 

To make it easier on plugin writers to validate that their commands/actions are doing the expected uploads, I added support in the `assertplugin` for capturing `FileUploadParameters` that triggered during the evaluation of a message. You might be interested in that and looking at its usage which is the test for that test function (`TestFileUploadCapture`).

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass