### PR TITLE
Remove Explicit WithBroadcast Answer Option to Help Plugin

### DIFF
--- a/help.go
+++ b/help.go
@@ -86,7 +86,7 @@ func (h *helpPlugin) showHelp(m *IncomingMessage) *Answer {
 		appendScheduledActions(&b, h.v.GetString(config.TimeLocationKey), h.pluginScheduledActions)
 	}
 
-	return &Answer{Text: b.String(), Options: []AnswerOption{AnswerInThreadWithBroadcast()}}
+	return &Answer{Text: b.String(), Options: []AnswerOption{AnswerInThread()}}
 }
 
 func appendActions(w io.Writer, actions []ActionDefinition) {

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -502,7 +502,7 @@ func TestIncomingTriggeringMessageUpdatedToTriggerDifferentAction(t *testing.T) 
 	assert.Equal(t, 0, len(rtmSender.rtmMsgs))
 }
 
-// TestHelpTriggeringNoUserInfoCache indirectly tests the user info caching (or absence of) by exercising the
+// TestHelpTriggeringWithUserInfoCache indirectly tests the user info caching (or absence of) by exercising the
 // help plugin which makes a call to it in order to find info about the user who requested help
 func TestHelpTriggeringWithUserInfoCache(t *testing.T) {
 	v := config.NewViperWithDefaults()
@@ -520,7 +520,7 @@ func testHelpTriggering(t *testing.T, v *viper.Viper) {
 	})
 
 	if assert.Equal(t, 2, len(sentMsgs)) {
-		assert.Equal(t, 5, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 4, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
 		assert.Equal(t, 3, len(sentMsgs[1].msgOptions))

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.15.0"
+	VERSION = "1.15.1"
 )


### PR DESCRIPTION
## What is this about
The `help` plugin always sets threading _and_ broadcast. The more I see this in the real world™, the more I think that the use of thread broadcast should be reduced to exceptional cases. And `help` doesn't qualify for this so this fixes that.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass