### PR TITLE
Fix Triggerer Rendering of Std Trigger List With Multi-Line Reactions

### DIFF
--- a/plugins/triggerer.go
+++ b/plugins/triggerer.go
@@ -56,7 +56,7 @@ func renderEmojiTrigger(trigger string, reaction string) (rendered string) {
 
 // renderStandardTrigger renders a standard trigger/reaction to be included in a listTriggers output
 func renderStandardTrigger(trigger string, reaction string) (rendered string) {
-	return fmt.Sprintf("`%s`\t=> `%s`", trigger, reaction)
+	return fmt.Sprintf("`%s`\t=> %s", trigger, renderStandardReaction(reaction))
 }
 
 // reactionEncoder is a function that takes in a raw reaction string and encodes it as a string to be persisted
@@ -486,7 +486,8 @@ func formatTriggers(triggers map[string]string, render elementRenderer) string {
 	bufw := bufio.NewWriter(&b)
 	w.Init(bufw, 5, 0, 1, ' ', 0)
 	for _, trigger := range keys {
-		fmt.Fprintf(w, "\t• %s\n", render(trigger, triggers[trigger]))
+		reaction := triggers[trigger]
+		fmt.Fprintf(w, "\t• %s\n", render(trigger, reaction))
 	}
 	fmt.Fprintf(w, "\n")
 

--- a/plugins/triggerer_test.go
+++ b/plugins/triggerer_test.go
@@ -97,15 +97,15 @@ func TestRegisterNewMultilineReactionTrigger(t *testing.T) {
 	assertplugin := assertplugin.New("bot")
 
 	// Register new trigger
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with ```{\nattributes=test\n}\n```"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => ```{\nattributes=test\n}\n```]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
+	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with ```{\n\"attributes\"=1.0\n}\n```"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => ```{\n\"attributes\"=1.0\n}\n```]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
 		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "```{\nattributes=test\n}\n```") && assertanswer.HasOptions(t, answers[0])
+			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "```{\n\"attributes\"=1.0\n}\n```") && assertanswer.HasOptions(t, answers[0])
 		})
 
 		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "```{\nattributes=test\n}\n```") && assertanswer.HasOptions(t, answers[0])
+			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "```{\n\"attributes\"=1.0\n}\n```") && assertanswer.HasOptions(t, answers[0])
 		})
 	}
 }
@@ -363,12 +363,12 @@ func TestListTriggers(t *testing.T) {
 	// Register triggers
 	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-	}) && assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on suddenly with https://suddenly.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`suddenly` => `https://suddenly.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
+	}) && assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on suddenly with ```{\n\"attributes\"=1.0\n}\n```"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`suddenly` => ```{\n\"attributes\"=1.0\n}\n```]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
 		// List triggers
 		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> list triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the current triggers: \n     • `deal with it` => `http://dealwithit.gif`\n     • `suddenly`     => `https://suddenly.gif`\n\n") &&
+			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the current triggers: \n     • `deal with it` => `http://dealwithit.gif`\n     • `suddenly`     => ```{\n\"attributes\"=1.0\n}\n```\n\n") &&
 				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 		})
 	}

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.15.1"
+	VERSION = "1.15.2"
 )


### PR DESCRIPTION
## What is this about
There were extra backticks surrounding multi-line reactions listed by triggerer's `list triggers` command. This fixes it.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass