### PR TITLE
Fix Default Command Not Honoring Threads

### DIFF
--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -460,6 +460,38 @@ func TestDirectMessageNotMatchingAnything(t *testing.T) {
 	assert.Equal(t, 0, len(rtmSender.rtmMsgs))
 }
 
+func TestDefaultCommandAnswerInChannel(t *testing.T) {
+	sentMsgs, updatedMsgs, deletedMsgs, rtmSender, _ := runSlackscotWithIncomingEventsWithLogs(t, nil, newTestPlugin(), []slack.RTMEvent{
+		// Trigger the command action
+		newRTMMessageEvent(newMessageEvent("Cgeneral", "<@BotUserID> mistyped command", "Alphonse", timestamp1)),
+	})
+
+	if assert.Equal(t, 1, len(sentMsgs)) {
+		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
+	}
+
+	assert.Equal(t, 0, len(updatedMsgs))
+	assert.Equal(t, 0, len(deletedMsgs))
+	assert.Equal(t, 0, len(rtmSender.rtmMsgs))
+}
+
+func TestDefaultCommandAnswerToMsgOnExistingThread(t *testing.T) {
+	sentMsgs, updatedMsgs, deletedMsgs, rtmSender, _ := runSlackscotWithIncomingEventsWithLogs(t, nil, newTestPlugin(), []slack.RTMEvent{
+		// Trigger the command action
+		newRTMMessageEvent(newMessageEvent("Cgeneral", "<@BotUserID> mistyped command", "Alphonse", timestamp1, optionMessageOnThread("1212314125"))),
+	})
+
+	if assert.Equal(t, 1, len(sentMsgs)) {
+		assert.Equal(t, 4, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
+	}
+
+	assert.Equal(t, 0, len(updatedMsgs))
+	assert.Equal(t, 0, len(deletedMsgs))
+	assert.Equal(t, 0, len(rtmSender.rtmMsgs))
+}
+
 func TestAtMessageNotMatchingAnything(t *testing.T) {
 	sentMsgs, updatedMsgs, deletedMsgs, rtmSender, _ := runSlackscotWithIncomingEventsWithLogs(t, nil, newTestPlugin(), []slack.RTMEvent{
 		// At Message but not matching the command

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.15.2"
+	VERSION = "1.15.3"
 )


### PR DESCRIPTION
## What is this about
The `default` command is a bit special and I missed it when I added the honoring of existing threads when posting reactions. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass