### PR TITLE
Support gcloud Credentials Being Rotated and Lazy Recreate the DS Client

### DIFF
--- a/store/datastoredb/datastoredb.go
+++ b/store/datastoredb/datastoredb.go
@@ -11,7 +11,9 @@ import (
 // to isolate data between different plugins
 type DatastoreDB struct {
 	*datastore.Client
-	kind string
+	kind             string
+	gcloudProjectID  string
+	gcloudClientOpts []option.ClientOption
 }
 
 // EntryValue represents an entity/entry value mapped to a datastore key
@@ -19,18 +21,25 @@ type EntryValue struct {
 	Value string `datastore:",noindex"`
 }
 
-// New returns a new instance of DatastoreDB for the given name (which maps to the datastore entity "Kind" and can
-// be thought of as the namespace). This function also requires a gcloudProjectID as well as at least one option to provide gcloud client credentials
-func New(name string, gcloudProjectID string, gcloudClientOpts ...option.ClientOption) (dsdb *DatastoreDB, err error) {
-	ctx := context.Background()
-	client, err := datastore.NewClient(ctx, gcloudProjectID, gcloudClientOpts...)
-	if err != nil {
-		return nil, err
-	}
+const (
+	// Try operations that could fail at most twice. The first time is assummed to potentially fail because
+	// of authentication errors when credentials have expired. The second time, a failure is probably
+	// something to report back
+	maxAttemptCount = 2
+)
 
+// New returns a new instance of DatastoreDB for the given name (which maps to the datastore entity "Kind" and can
+// be thought of as the namespace). This function also requires a gcloudProjectID as well as at least one option to provide gcloud client credentials.
+// Note that in order to support a deployment where credentials can get updated, the gcloudClientOpts should use
+// something like option.WithCredentialsFile with the credentials file being updated on disk so that when reconnecting
+// on a failure, the updated credentials are visible through the same gcloud client options
+func New(name string, gcloudProjectID string, gcloudClientOpts ...option.ClientOption) (dsdb *DatastoreDB, err error) {
 	dsdb = new(DatastoreDB)
-	dsdb.Client = client
 	dsdb.kind = name
+	dsdb.gcloudProjectID = gcloudProjectID
+	dsdb.gcloudClientOpts = gcloudClientOpts
+
+	dsdb.connectClient()
 
 	err = dsdb.testDB()
 	if err = dsdb.testDB(); err != nil {
@@ -39,6 +48,18 @@ func New(name string, gcloudProjectID string, gcloudClientOpts ...option.ClientO
 	}
 
 	return dsdb, nil
+}
+
+// connectClient establishes a new datastore Client connection
+// Note: must be called after gcloudProjectID and gCloudClientOpts has been set
+func (dsdb *DatastoreDB) connectClient() (err error) {
+	ctx := context.Background()
+	dsdb.Client, err = datastore.NewClient(ctx, dsdb.gcloudProjectID, dsdb.gcloudClientOpts...)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // testDB makes a lightweight call to the datastore to validate connectivity and credentials
@@ -60,7 +81,19 @@ func (dsdb *DatastoreDB) GetString(key string) (value string, err error) {
 
 	var e EntryValue
 	k := datastore.NameKey(dsdb.kind, key, nil)
-	if err := dsdb.Get(ctx, k, &e); err != nil {
+
+	attempt := 0
+	err = dsdb.Get(ctx, k, &e)
+
+	// Retry once and try a reconnect if the error is recoverable (like unauthenticated error)
+	for attempt < maxAttemptCount && err != nil && shouldRetry(err) {
+		dsdb.connectClient()
+
+		attempt = attempt + 1
+		err = dsdb.Get(ctx, k, &e)
+	}
+
+	if err != nil {
 		return "", err
 	}
 
@@ -72,7 +105,17 @@ func (dsdb *DatastoreDB) PutString(key string, value string) (err error) {
 	ctx := context.Background()
 	k := datastore.NameKey(dsdb.kind, key, nil)
 
+	attempt := 0
 	_, err = dsdb.Put(ctx, k, &EntryValue{Value: value})
+
+	// Retry once and try a reconnect if the error is recoverable (like unauthenticated error)
+	for attempt < maxAttemptCount && err != nil && shouldRetry(err) {
+		dsdb.connectClient()
+
+		attempt = attempt + 1
+		_, err = dsdb.Put(ctx, k, &EntryValue{Value: value})
+	}
+
 	return err
 }
 
@@ -82,7 +125,18 @@ func (dsdb *DatastoreDB) DeleteString(key string) (err error) {
 	ctx := context.Background()
 	k := datastore.NameKey(dsdb.kind, key, nil)
 
-	return dsdb.Delete(ctx, k)
+	attempt := 0
+	err = dsdb.Delete(ctx, k)
+
+	// Retry once and try a reconnect if the error is recoverable (like unauthenticated error)
+	for attempt < maxAttemptCount && err != nil && shouldRetry(err) {
+		dsdb.connectClient()
+
+		attempt = attempt + 1
+		err = dsdb.Delete(ctx, k)
+	}
+
+	return err
 }
 
 // Scan returns all key/values from the database
@@ -92,9 +146,14 @@ func (dsdb *DatastoreDB) Scan() (entries map[string]string, err error) {
 	ctx := context.Background()
 	var vals []*EntryValue
 
+	attempt := 0
 	keys, err := dsdb.GetAll(ctx, datastore.NewQuery(dsdb.kind), &vals)
-	if err != nil {
-		return nil, err
+
+	// Retry once and try a reconnect if the error is recoverable (like unauthenticated error)
+	for attempt < maxAttemptCount && err != nil && shouldRetry(err) {
+		dsdb.connectClient()
+		attempt = attempt + 1
+		keys, err = dsdb.GetAll(ctx, datastore.NewQuery(dsdb.kind), &vals)
 	}
 
 	for i, key := range keys {
@@ -102,6 +161,19 @@ func (dsdb *DatastoreDB) Scan() (entries map[string]string, err error) {
 	}
 
 	return entries, nil
+}
+
+// shouldRetry returns true if the given error should be retried or false if not.
+// In order to determine this, one approach would be to only retry on a
+// statusError (https://github.com/grpc/grpc-go/blob/master/status/status.go#L43)
+// with code Unauthenticated (https://godoc.org/google.golang.org/grpc/codes) but that's made
+// trickier by the statusError not being promoted outside the package (checking for the Error string
+// would be reasonable but a bit dirty).
+// Alternatively, and what's done here is to be a little conservative and retry on everything except
+// ErrNoSuchEntity, ErrInvalidEntityType and ErrInvalidKey which are not things retries would help
+// with. This means we could still retry when it's pointless to do so at the expense of added latency.
+func shouldRetry(err error) bool {
+	return err != datastore.ErrNoSuchEntity && err != datastore.ErrInvalidEntityType && err != datastore.ErrInvalidKey
 }
 
 // Close closes the underlying datastore client

--- a/store/datastoredb/doc.go
+++ b/store/datastoredb/doc.go
@@ -8,6 +8,16 @@ Requirements for the Google Cloud Datastore integration:
   - Google Cloud Credentials (typically in the form of a json file
     with credentials from https://console.cloud.google.com/apis/credentials/serviceaccountkey)
 
+Note: for deployments using credentials rotation, the current solution supports this use-case
+with a naive lazy recreation of the client on error. In order for fresh credentials to be
+effective when an authentication error happens, the credential client options must reflect
+the fresh credentials. One example of this is
+
+ option.WithCredentialsFile(filename)
+
+Since that option points to a filename, the fresh credentials at that file location
+would be refreshed on client recreation.
+
 Example code:
 
 	import (

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.15.3"
+	VERSION = "1.15.4"
 )


### PR DESCRIPTION
## What is this about
When a deployment uses credentials rotation/leases, the `datastoredb` would eventually stop working and would error out on any operation with something like:

```
rpc error: code = Unauthenticated desc = transport: oauth2: cannot fetch token: 400 Bad Request Response: { "error": "invalid_grant", "error_description": "Not a valid email or user ID."}
```

This change addresses that by lazy reconnecting/recreating the `datastore` client when an error is encountered that _isn't_ one of:
*   datastore.ErrNoSuchEntity
*   datastore.ErrInvalidEntityType
*   datastore.ErrInvalidKey

Since now `datastoredb` has some meaningful logic instead of being a thin wrapper, I added an item to my backlog to add a test for it which will likely require some decoupling by adding small interfaces. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass