### PR TITLE
Fix Stackoverflow on All Invocations of datastore Client Methods

### DIFF
--- a/store/datastoredb/datastore.go
+++ b/store/datastoredb/datastore.go
@@ -42,27 +42,27 @@ type datastorer interface {
 	io.Closer
 	Delete(c context.Context, k *datastore.Key) (err error)
 	Get(c context.Context, k *datastore.Key, dest interface{}) (err error)
-	GetAll(c context.Context, query interface{}, dest interface{}) (keys []*datastore.Key, err error)
+	GetAll(c context.Context, query *datastore.Query, dest interface{}) (keys []*datastore.Key, err error)
 	Put(c context.Context, k *datastore.Key, v interface{}) (key *datastore.Key, err error)
 }
 
 // Delete deletes the entity for the given key. See https://godoc.org/cloud.google.com/go/datastore#Client.Delete
 func (ds *gcdatastore) Delete(c context.Context, k *datastore.Key) (err error) {
-	return ds.Delete(c, k)
+	return ds.Client.Delete(c, k)
 }
 
 // Get loads the entity stored for key into dst. See https://godoc.org/cloud.google.com/go/datastore#Client.Get
 func (ds *gcdatastore) Get(c context.Context, k *datastore.Key, dest interface{}) (err error) {
-	return ds.Get(c, k, dest)
+	return ds.Client.Get(c, k, dest)
 }
 
 // GetAll runs the provided query in the given context and returns all keys that match that query.
 // See https://godoc.org/cloud.google.com/go/datastore#Client.GetAll
-func (ds *gcdatastore) GetAll(c context.Context, query interface{}, dest interface{}) (keys []*datastore.Key, err error) {
-	return ds.GetAll(c, query, dest)
+func (ds *gcdatastore) GetAll(c context.Context, query *datastore.Query, dest interface{}) (keys []*datastore.Key, err error) {
+	return ds.Client.GetAll(c, query, dest)
 }
 
 // Put saves the entity src into the datastore with the given key. See https://godoc.org/cloud.google.com/go/datastore#Client.Put
 func (ds *gcdatastore) Put(c context.Context, k *datastore.Key, v interface{}) (key *datastore.Key, err error) {
-	return ds.Put(c, k, v)
+	return ds.Client.Put(c, k, v)
 }

--- a/store/datastoredb/datastoredb_internal_test.go
+++ b/store/datastoredb/datastoredb_internal_test.go
@@ -60,11 +60,11 @@ func (md *mockDatastore) Get(c context.Context, k *datastore.Key, dest interface
 
 // GetAll mocks a GetAll datastore call. The base was inspired by the generated mock implementation via https://github.com/vektra/mockery
 // to get an idea of how to support returner functions
-func (md *mockDatastore) GetAll(c context.Context, query interface{}, dest interface{}) (keys []*datastore.Key, err error) {
+func (md *mockDatastore) GetAll(c context.Context, query *datastore.Query, dest interface{}) (keys []*datastore.Key, err error) {
 	ret := md.Called(c, query, dest)
 
 	var r0 []*datastore.Key
-	if rf, ok := ret.Get(0).(func(context.Context, interface{}, interface{}) []*datastore.Key); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *datastore.Query, interface{}) []*datastore.Key); ok {
 		r0 = rf(c, query, dest)
 	} else {
 		if ret.Get(0) != nil {
@@ -73,7 +73,7 @@ func (md *mockDatastore) GetAll(c context.Context, query interface{}, dest inter
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, interface{}, interface{}) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *datastore.Query, interface{}) error); ok {
 		r1 = rf(c, query, dest)
 	} else {
 		r1 = ret.Error(1)
@@ -210,7 +210,7 @@ func TestSuccessfulScan(t *testing.T) {
 	// and set that one value for the key that we're returning in the output. This should be much easier but the datastore API is
 	// not the most elegant in that regards so that's just something to deal with
 	var vals []*EntryValue
-	mockDS.On("GetAll", mock.Anything, datastore.NewQuery(testEntityName), &vals).Return(func(c context.Context, query interface{}, dest interface{}) (keys []*datastore.Key) {
+	mockDS.On("GetAll", mock.Anything, datastore.NewQuery(testEntityName), &vals).Return(func(c context.Context, query *datastore.Query, dest interface{}) (keys []*datastore.Key) {
 		if vals, ok := dest.(*[]*EntryValue); ok {
 			if vals != nil {
 				(*vals) = make([]*EntryValue, 1)

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.15.5"
+	VERSION = "1.15.6"
 )


### PR DESCRIPTION
## What is this about
In adding an interface for `datastorer` in the last commit, I introduced a stack overflow because calls to the datastore would use itself instead of calling the embedded client. This was stupid and this fixes it.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass