### PR TITLE
Fix Triggerer Reacting on Registered Trigger Being Substrings on Words

### DIFF
--- a/plugins/triggerer_test.go
+++ b/plugins/triggerer_test.go
@@ -75,6 +75,10 @@ func TestRegisterNewTrigger(t *testing.T) {
 			return assert.Empty(t, answers) && assert.Empty(t, emojis)
 		})
 
+		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with itself"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+			return assert.Empty(t, answers) && assert.Empty(t, emojis)
+		})
+
 		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://dealwithit.gif") && assertanswer.HasOptions(t, answers[0])
 		})
@@ -120,6 +124,10 @@ func TestRegisterNewEmojiTrigger(t *testing.T) {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new emoji trigger [`deal with it` => :boom:, :cat:]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
 		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with nothing"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+			return assert.Empty(t, emojis) && assert.Empty(t, answers)
+		})
+
+		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with itself"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, emojis) && assert.Empty(t, answers)
 		})
 

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.15.6"
+	VERSION = "1.15.7"
 )


### PR DESCRIPTION
## What is this about
Triggers registered would still match and react when a message would include the trigger as a substring (i.e. a trigger on `late` would provoke a reaction on a message including `later`). This now fixes it by matching a trigger only if it's surrounded by word boundaries. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass