### PR TITLE
Port Over Emoji Banner Maker Test to Use assertplugin

### DIFF
--- a/plugins/emojibanner.go
+++ b/plugins/emojibanner.go
@@ -128,11 +128,11 @@ func validateAndRenderEmoji(message string, regex *regexp.Regexp, renderer *figl
 				return renderBanner(word, emoji, renderer, options)
 			}
 
-			return &slackscot.Answer{Text: "Wrong usage (word longer than 5 characters): emoji banner <word of 5 characters or less> <emoji>"}
+			return &slackscot.Answer{Text: "`Wrong usage` (word *longer* than `5` characters): emoji banner `<word of 5 characters or less>` `<emoji>`"}
 		}
 	}
 
-	return &slackscot.Answer{Text: "Wrong usage: emoji banner <word of 5 characters or less> <emoji>"}
+	return &slackscot.Answer{Text: "`Wrong usage`: emoji banner `<word of 5 characters or less>` `<emoji>`"}
 }
 
 func renderBanner(word, emoji string, renderer *figlet4go.AsciiRender, options *figlet4go.RenderOptions) *slackscot.Answer {

--- a/plugins/fingerquoter_test.go
+++ b/plugins/fingerquoter_test.go
@@ -154,9 +154,9 @@ func TestNoAnswerWhenCorruptedTimestamp(t *testing.T) {
 	var b strings.Builder
 	logger := log.New(&b, "", 0)
 
-	assertplugin := assertplugin.New("bot", assertplugin.OptionLog(logger))
+	assertplugin := assertplugin.New(t, "bot", assertplugin.OptionLog(logger))
 
-	assertplugin.AnswersAndReacts(t, &f.Plugin, &slack.Msg{Text: "This is a text with longer and shorter words", Timestamp: "NotAFloatValue"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "This is a text with longer and shorter words", Timestamp: "NotAFloatValue"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers) && assert.Contains(t, b.String(), "error converting timestamp to float")
 	})
 }
@@ -168,9 +168,9 @@ func TestQuotingOfSingleLongWord(t *testing.T) {
 	f, err := plugins.NewFingerQuoter(pc)
 	assert.Nil(t, err)
 
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(t, &f.Plugin, &slack.Msg{Text: "Do I belong or not?", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "Do I belong or not?", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"belong\"")
 	})
 }
@@ -182,9 +182,9 @@ func TestNotQuotingPartsOfURLs(t *testing.T) {
 	f, err := plugins.NewFingerQuoter(pc)
 	assert.Nil(t, err)
 
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(t, &f.Plugin, &slack.Msg{Text: "https://google.com/query?bigfoot=friend", Timestamp: "1546833310.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "https://google.com/query?bigfoot=friend", Timestamp: "1546833310.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers)
 	})
 }
@@ -197,10 +197,10 @@ func TestConsistentWordQuotingWithSameTimestamp(t *testing.T) {
 	f, err := plugins.NewFingerQuoter(pc)
 	assert.Nil(t, err)
 
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Validate one pick with a different timestamp
-	assertplugin.AnswersAndReacts(t, &f.Plugin, &slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
+	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
 			Where the lock that you locked in the suite says there's no prying. When the breath that you breathed in 
 			the street screams there's no science`, Timestamp: "1546833315.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"breath\"")
@@ -208,7 +208,7 @@ func TestConsistentWordQuotingWithSameTimestamp(t *testing.T) {
 
 	// Validate that calling the answer function a hundred times with the same timestamp results in the same pick
 	for i := 0; i < 100; i++ {
-		if !assertplugin.AnswersAndReacts(t, &f.Plugin, &slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
+		if !assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
 			Where the lock that you locked in the suite says there's no prying. When the breath that you breathed in 
 			the street screams there's no science`, Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"street\"")
@@ -219,7 +219,7 @@ func TestConsistentWordQuotingWithSameTimestamp(t *testing.T) {
 
 	// Validate that a timestamp *almost* equal to the prior one (except for decimals) results in something different to make sure
 	// we don't ignore those
-	assertplugin.AnswersAndReacts(t, &f.Plugin, &slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
+	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
 			Where the lock that you locked in the suite says there's no prying. When the breath that you breathed in 
 			the street screams there's no science`, Timestamp: "1546833210.036907"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"Where\"")

--- a/plugins/triggerer_test.go
+++ b/plugins/triggerer_test.go
@@ -65,29 +65,29 @@ func TestRegisterNewTrigger(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
 
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with nothing"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with nothing"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, answers) && assert.Empty(t, emojis)
 		})
 
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with itself"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with itself"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, answers) && assert.Empty(t, emojis)
 		})
 
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://dealwithit.gif") && assertanswer.HasOptions(t, answers[0])
 		})
 
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://dealwithit.gif") && assertanswer.HasOptions(t, answers[0])
 		})
 
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "don't tell me to deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "don't tell me to deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://dealwithit.gif") && assertanswer.HasOptions(t, answers[0])
 		})
 
@@ -98,17 +98,17 @@ func TestRegisterNewMultilineReactionTrigger(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
 
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with ```{\n\"attributes\"=1.0\n}\n```"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with ```{\n\"attributes\"=1.0\n}\n```"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => ```{\n\"attributes\"=1.0\n}\n```]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "```{\n\"attributes\"=1.0\n}\n```") && assertanswer.HasOptions(t, answers[0])
 		})
 
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "```{\n\"attributes\"=1.0\n}\n```") && assertanswer.HasOptions(t, answers[0])
 		})
 	}
@@ -118,24 +118,24 @@ func TestRegisterNewEmojiTrigger(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
 
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :boom::cat:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :boom::cat:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new emoji trigger [`deal with it` => :boom:, :cat:]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with nothing"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with nothing"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, emojis) && assert.Empty(t, answers)
 		})
 
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with itself"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with itself"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, emojis) && assert.Empty(t, answers)
 		})
 
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, answers) && assert.Contains(t, emojis, "boom", "cat")
 		})
 
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, answers) && assert.Contains(t, emojis, "boom", "cat")
 		})
 	}
@@ -145,9 +145,9 @@ func TestRegisterNewEmojiTriggerWithoutEmojis(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
 
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with what are emojis?"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with what are emojis?"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Invalid reaction for emoji trigger: `<reaction emojis>` doesn't include any emojis") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	})
 }
@@ -156,16 +156,16 @@ func TestErrorGettingTriggersWhenReacting(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
 
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
 		storer.returnErrorOnReads = true
 
 		// Validate trigger reaction is absent because of the error listing triggers
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, answers) && assert.Empty(t, emojis)
 		})
 	}
@@ -176,10 +176,10 @@ func TestErrorGettingTriggersWhenReacting(t *testing.T) {
 func TestErrorGettingTriggersWhenAnswering(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
 		storer.returnErrorOnReads = true
@@ -206,9 +206,9 @@ func TestNoReactionWhenNoTriggers(t *testing.T) {
 func TestNoAnswersAndNoEmojisWhenNoTriggers(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers) && assert.Empty(t, emojis)
 	})
 }
@@ -216,13 +216,13 @@ func TestNoAnswersAndNoEmojisWhenNoTriggers(t *testing.T) {
 func TestErrorOnRegisterNewTrigger(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Have the storer return an error on write
 	storer.returnErrorOnWrites = true
 
 	// Register new trigger and get an error persisting it
-	assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error persisting standard trigger [`deal with it` => `http://dealwithit.gif`]: `Mock error`") &&
 			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	})
@@ -231,17 +231,17 @@ func TestErrorOnRegisterNewTrigger(t *testing.T) {
 func TestUpdateTrigger(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
-		if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://betterdealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://betterdealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Replaced standard trigger reaction for [`deal with it`] with [`http://betterdealwithit.gif`] (was [`http://dealwithit.gif`] previously)") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 		}) {
 			// Validate updated trigger reaction
-			assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+			assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 				return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://betterdealwithit.gif") && assertanswer.HasOptions(t, answers[0])
 			})
 		}
@@ -251,17 +251,17 @@ func TestUpdateTrigger(t *testing.T) {
 func TestUpdateEmojiTrigger(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :man-in-suit:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :man-in-suit:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new emoji trigger [`deal with it` => :man-in-suit:]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
-		if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :boom:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :boom:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Replaced emoji trigger reaction for [`deal with it`] with [:boom:] (was [:man-in-suit:] previously)") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 		}) {
 			// Validate updated trigger reaction
-			assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+			assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 				return assert.Empty(t, answers) && assert.Contains(t, emojis, "boom")
 			})
 		}
@@ -271,17 +271,17 @@ func TestUpdateEmojiTrigger(t *testing.T) {
 func TestErrorOnUpdateTrigger(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
 		// Have the storer return an error on write
 		storer.returnErrorOnWrites = true
 
 		// Attempt to update trigger and expect error message
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://betterdealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://betterdealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error persisting standard trigger [`deal with it` => `http://betterdealwithit.gif`]: `Mock error`") &&
 				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 		})
@@ -292,18 +292,18 @@ func TestDeleteTrigger(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
 
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
-		if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Deleted standard trigger [`deal with it` => `http://dealwithit.gif`]") &&
 				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 		}) {
 			// Validate no reaction
-			assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+			assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 				return assert.Empty(t, emojis) && assert.Empty(t, answers)
 			})
 		}
@@ -313,18 +313,18 @@ func TestDeleteTrigger(t *testing.T) {
 func TestDeleteEmojiTrigger(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :boom:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :boom:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new emoji trigger [`deal with it` => :boom:]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
-		if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> forget emoji trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> forget emoji trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Deleted emoji trigger [`deal with it` => :boom:]") &&
 				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 		}) {
 			// Validate no reaction
-			assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+			assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 				return assert.Empty(t, emojis) && assert.Empty(t, answers)
 			})
 		}
@@ -335,10 +335,10 @@ func TestDeleteTriggerNotFound(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
 
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Delete trigger
-	assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "No standard trigger found on `deal with it`") &&
 			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	})
@@ -347,16 +347,16 @@ func TestDeleteTriggerNotFound(t *testing.T) {
 func TestErrorOnDeleteTrigger(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
 		// Have the storer return an error on writes
 		storer.returnErrorOnWrites = true
 
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error removing standard trigger [`deal with it` => `http://dealwithit.gif`]: `Mock error`") &&
 				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 		})
@@ -366,16 +366,16 @@ func TestErrorOnDeleteTrigger(t *testing.T) {
 func TestListTriggers(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Register triggers
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-	}) && assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on suddenly with ```{\n\"attributes\"=1.0\n}\n```"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	}) && assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on suddenly with ```{\n\"attributes\"=1.0\n}\n```"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`suddenly` => ```{\n\"attributes\"=1.0\n}\n```]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
 		// List triggers
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> list triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> list triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the current triggers: \n     • `deal with it` => `http://dealwithit.gif`\n     • `suddenly`     => ```{\n\"attributes\"=1.0\n}\n```\n\n") &&
 				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 		})
@@ -385,16 +385,16 @@ func TestListTriggers(t *testing.T) {
 func TestListEmojiTriggers(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Register triggers
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :sunglasses:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :sunglasses:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new emoji trigger [`deal with it` => :sunglasses:]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-	}) && assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on suddenly with :scream::ghost:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	}) && assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on suddenly with :scream::ghost:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new emoji trigger [`suddenly` => :scream:, :ghost:]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
 		// List triggers
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> list emoji triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> list emoji triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the current emoji triggers: \n     • `deal with it` => :sunglasses:\n     • `suddenly`     => :scream:, :ghost:\n\n") &&
 				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 		})
@@ -404,17 +404,17 @@ func TestListEmojiTriggers(t *testing.T) {
 func TestErrorOnListTriggers(t *testing.T) {
 	storer := newInMemoryStorer()
 	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger
-	if assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
 		// Have the storer return an error on reads
 		storer.returnErrorOnReads = true
 
 		// List triggers
-		assertplugin.AnswersAndReacts(t, &triggerer.Plugin, &slack.Msg{Text: "<@bot> list triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> list triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error loading triggers:\n```Mock error```") &&
 				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 		})

--- a/test/assertplugin/assertplugin.go
+++ b/test/assertplugin/assertplugin.go
@@ -24,6 +24,7 @@ import (
 // sending test messages for processing
 type Asserter struct {
 	botUserID string
+	t         *testing.T
 	logger    *log.Logger
 }
 
@@ -31,9 +32,10 @@ type Asserter struct {
 // (only include the id without the '@' prefix).
 // The botUserId is used in order to detect commands formed with
 // <@botUserId>
-func New(botUserID string, options ...Option) (a *Asserter) {
+func New(t *testing.T, botUserID string, options ...Option) (a *Asserter) {
 	a = new(Asserter)
 	a.botUserID = botUserID
+	a.t = t
 
 	for _, option := range options {
 		option(a)
@@ -66,20 +68,20 @@ type ResultWithUploadsValidator func(t *testing.T, answers []*slackscot.Answer, 
 // AnswersAndReacts drives a plugin and collects Answers as well as emoji reactions. Once all of those have been collected,
 // it passes handling to a validator to assert the expected answers and emoji reactions. It follows the style of
 // github.com/stretchr/testify/assert as far as returning true/false to indicate success for further nested testing.
-func (a *Asserter) AnswersAndReacts(t *testing.T, p *slackscot.Plugin, m *slack.Msg, validate ResultValidator) (valid bool) {
+func (a *Asserter) AnswersAndReacts(p *slackscot.Plugin, m *slack.Msg, validate ResultValidator) (valid bool) {
 	answers, emojis, _ := a.injectServicesAndRun(p, m)
 
-	return validate(t, answers, emojis)
+	return validate(a.t, answers, emojis)
 }
 
 // AnswersAndReactsWithUploads drives a plugin and collects Answers as well as emoji reactions and file uploads.
 // Once all of those have been collected, it passes handling to a validator to assert the expected answers,
 // emoji reactions and file uploads. It follows the style of github.com/stretchr/testify/assert as far as
 // returning true/false to indicate success for further nested testing.
-func (a *Asserter) AnswersAndReactsWithUploads(t *testing.T, p *slackscot.Plugin, m *slack.Msg, validate ResultWithUploadsValidator) (valid bool) {
+func (a *Asserter) AnswersAndReactsWithUploads(p *slackscot.Plugin, m *slack.Msg, validate ResultWithUploadsValidator) (valid bool) {
 	answers, emojis, fileUploads := a.injectServicesAndRun(p, m)
 
-	return validate(t, answers, emojis, fileUploads)
+	return validate(a.t, answers, emojis, fileUploads)
 }
 
 // injectServicesAndRun injects services in the plugin, drives all of its actions and returns the answers and captured data

--- a/test/assertplugin/assertplugin_test.go
+++ b/test/assertplugin/assertplugin_test.go
@@ -86,30 +86,30 @@ func (mlt *myLittleTester) emojiReact(m *slackscot.IncomingMessage) *slackscot.A
 
 func TestCommandResultNonValid(t *testing.T) {
 	mockT := new(testing.T)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(mockT, "bot")
 	myLittleTester := newLittleTester()
 
-	assert.Equal(t, false, assertplugin.AnswersAndReacts(mockT, &myLittleTester.Plugin, &slack.Msg{Text: "<@bot> tell me where the black-capped chickadee is"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assert.Equal(t, false, assertplugin.AnswersAndReacts(&myLittleTester.Plugin, &slack.Msg{Text: "<@bot> tell me where the black-capped chickadee is"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 10)
 	}))
 }
 
 func TestCommandResultValid(t *testing.T) {
 	mockT := new(testing.T)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(mockT, "bot")
 	myLittleTester := newLittleTester()
 
-	assert.Equal(t, true, assertplugin.AnswersAndReacts(mockT, &myLittleTester.Plugin, &slack.Msg{Text: "<@bot> tell me where the black-capped chickadee is"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assert.Equal(t, true, assertplugin.AnswersAndReacts(&myLittleTester.Plugin, &slack.Msg{Text: "<@bot> tell me where the black-capped chickadee is"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "👀 in the 🌲")
 	}))
 }
 
 func TestFileUploadCapture(t *testing.T) {
 	mockT := new(testing.T)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(mockT, "bot")
 	myLittleTester := newLittleTester()
 
-	assert.Equal(t, true, assertplugin.AnswersAndReactsWithUploads(mockT, &myLittleTester.Plugin, &slack.Msg{Text: "<@bot> tell me where the black-capped chickadee is"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string, fileUploads []slack.FileUploadParameters) bool {
+	assert.Equal(t, true, assertplugin.AnswersAndReactsWithUploads(&myLittleTester.Plugin, &slack.Msg{Text: "<@bot> tell me where the black-capped chickadee is"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string, fileUploads []slack.FileUploadParameters) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "👀 in the 🌲") && assert.Len(t, fileUploads, 1) && assert.Equal(t, slack.FileUploadParameters{Filename: "imageOfABirdInATree.png", Filetype: "image/png", Title: "Look"}, fileUploads[0])
 	}))
 }
@@ -119,50 +119,50 @@ func TestLoggerAttached(t *testing.T) {
 
 	var b strings.Builder
 	logger := log.New(&b, "", 0)
-	assertplugin := assertplugin.New("bot", assertplugin.OptionLog(logger))
+	assertplugin := assertplugin.New(mockT, "bot", assertplugin.OptionLog(logger))
 	myLittleTester := newLittleTester()
 
-	assert.Equal(t, true, assertplugin.AnswersAndReacts(mockT, &myLittleTester.Plugin, &slack.Msg{Text: "<@bot> tell me where the black-capped chickadee is"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assert.Equal(t, true, assertplugin.AnswersAndReacts(&myLittleTester.Plugin, &slack.Msg{Text: "<@bot> tell me where the black-capped chickadee is"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "👀 in the 🌲") && assert.Equal(t, "a debug statement\n", b.String())
 	}))
 }
 
 func TestHearResultValid(t *testing.T) {
 	mockT := new(testing.T)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(mockT, "bot")
 	myLittleTester := newLittleTester()
 
-	assert.Equal(t, true, assertplugin.AnswersAndReacts(mockT, &myLittleTester.Plugin, &slack.Msg{Text: "are you up?"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assert.Equal(t, true, assertplugin.AnswersAndReacts(&myLittleTester.Plugin, &slack.Msg{Text: "are you up?"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "I'm 😴, you?")
 	}))
 }
 
 func TestDirectCommandResultValid(t *testing.T) {
 	mockT := new(testing.T)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(mockT, "bot")
 	myLittleTester := newLittleTester()
 
-	assert.Equal(t, true, assertplugin.AnswersAndReacts(mockT, &myLittleTester.Plugin, &slack.Msg{Text: "tell me where the black-capped chickadee is", Channel: "DTOTHEBOT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assert.Equal(t, true, assertplugin.AnswersAndReacts(&myLittleTester.Plugin, &slack.Msg{Text: "tell me where the black-capped chickadee is", Channel: "DTOTHEBOT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "👀 in the 🌲")
 	}))
 }
 
 func TestEmojiReaction(t *testing.T) {
 	mockT := new(testing.T)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(mockT, "bot")
 	myLittleTester := newLittleTester()
 
-	assert.Equal(t, true, assertplugin.AnswersAndReacts(mockT, &myLittleTester.Plugin, &slack.Msg{Text: "blue jays"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assert.Equal(t, true, assertplugin.AnswersAndReacts(&myLittleTester.Plugin, &slack.Msg{Text: "blue jays"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers) && assert.Contains(t, emojis, "owl")
 	}))
 }
 
 func TestMultipleAnswersWithEmojiReaction(t *testing.T) {
 	mockT := new(testing.T)
-	assertplugin := assertplugin.New("bot")
+	assertplugin := assertplugin.New(mockT, "bot")
 	myLittleTester := newLittleTester()
 
-	assert.Equal(t, true, assertplugin.AnswersAndReacts(mockT, &myLittleTester.Plugin, &slack.Msg{Text: "hey, are you up? I think I just saw blue jays"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assert.Equal(t, true, assertplugin.AnswersAndReacts(&myLittleTester.Plugin, &slack.Msg{Text: "hey, are you up? I think I just saw blue jays"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 2) && assertanswer.HasText(t, answers[0], "I'm 😴, you?") && assertanswer.HasText(t, answers[1], "hey wut?") && assert.Contains(t, emojis, "owl")
 	}))
 }

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.15.7"
+	VERSION = "1.15.8"
 )


### PR DESCRIPTION
## What is this about
Coming back and revisiting the `emojibanner_test` after having gained some wisdom from writing more tests (and after having created `assertplugin`). 

This also moves the `t.testing` parameter in `assertplugin` to the `New` instead of having it passed on each `AnswersAndReacts` assertion. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass