### PR TITLE
Migrate karma_test to Use assertplugin

### DIFF
--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -1,16 +1,15 @@
 package plugins_test
 
 import (
-	"fmt"
 	"github.com/alexandre-normand/slackscot"
 	"github.com/alexandre-normand/slackscot/plugins"
 	"github.com/alexandre-normand/slackscot/store"
+	"github.com/alexandre-normand/slackscot/test/assertanswer"
+	"github.com/alexandre-normand/slackscot/test/assertplugin"
 	"github.com/nlopes/slack"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
-	"log"
 	"os"
-	"strings"
 	"testing"
 )
 
@@ -23,42 +22,41 @@ func (u userInfoFinder) GetUserInfo(userID string) (user *slack.User, err error)
 
 func TestKarmaMatchesAndAnswers(t *testing.T) {
 	testCases := []struct {
-		text            string
-		expectedMatches map[string]bool
-		expectedAnswers map[string]string
+		text           string
+		expectedAnswer string
 	}{
-		{"creek++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`creek` just gained a level (`creek`: 1)"}},
-		{"creek--", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`creek` just lost a life (`creek`: 0)"}},
-		{"the creek++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`creek` just gained a level (`creek`: 1)"}},
-		{"our creek++ is nice", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`creek` just gained a level (`creek`: 2)"}},
-		{"our creek++ is really nice", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`creek` just gained a level (`creek`: 3)"}},
-		{"oceans++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`oceans` just gained a level (`oceans`: 1)"}},
-		{"oceans++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`oceans` just gained a level (`oceans`: 2)"}},
-		{"nettle++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`nettle` just gained a level (`nettle`: 1)"}},
-		{"salmon++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`salmon` just gained a level (`salmon`: 1)"}},
-		{"salmon++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`salmon` just gained a level (`salmon`: 2)"}},
-		{"salmon++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`salmon` just gained a level (`salmon`: 3)"}},
-		{"salmon++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`salmon` just gained a level (`salmon`: 4)"}},
-		{"dams--", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`dams` just lost a life (`dams`: -1)"}},
-		{"dams--", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`dams` just lost a life (`dams`: -2)"}},
-		{"karma", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": false}, make(map[string]string)},
-		{"karma top 2", map[string]bool{"h[0]": false, "c[0]": true, "c[1]": false}, map[string]string{"c[0]": "Here are the top 2 things: \n```4    salmon\n3    creek\n```\n"}},
-		{"karma worst 2", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": true}, map[string]string{"c[1]": "Here are the worst 2 things: \n```-2   dams\n1    nettle\n```\n"}},
-		{"<@U21355>++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 1)"}},
-		{"<@U21355>++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 2)"}},
-		{"<@U21355>++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 3)"}},
-		{"<@U21355>++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 4)"}},
-		{"<@U21355>++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 5)"}},
-		{"<@U21355>++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 6)"}},
-		{"karma top 1", map[string]bool{"h[0]": false, "c[0]": true, "c[1]": false}, map[string]string{"c[0]": "Here are the top 1 things: \n```6    Bernard Tremblay\n```\n"}},
-		{"don't++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`don't` just gained a level (`don't`: 1)"}},
-		{"under-the-bridge++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`the-bridge` just gained a level (`the-bridge`: 1)"}},
-		{"Jean-Michel++", map[string]bool{"h[0]": true, "c[0]": false, "c[1]": false}, map[string]string{"h[0]": "`Jean-Michel` just gained a level (`Jean-Michel`: 1)"}},
-		{"+----------+", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": false}, map[string]string{}},
-		{"---", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": false}, map[string]string{}},
-		{"+++", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": false}, map[string]string{}},
-		{"karma worst", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": false}, map[string]string{}},
-		{"karma top", map[string]bool{"h[0]": false, "c[0]": false, "c[1]": false}, map[string]string{}},
+		{"creek++", "`creek` just gained a level (`creek`: 1)"},
+		{"creek--", "`creek` just lost a life (`creek`: 0)"},
+		{"the creek++", "`creek` just gained a level (`creek`: 1)"},
+		{"our creek++ is nice", "`creek` just gained a level (`creek`: 2)"},
+		{"our creek++ is really nice", "`creek` just gained a level (`creek`: 3)"},
+		{"oceans++", "`oceans` just gained a level (`oceans`: 1)"},
+		{"oceans++", "`oceans` just gained a level (`oceans`: 2)"},
+		{"nettle++", "`nettle` just gained a level (`nettle`: 1)"},
+		{"salmon++", "`salmon` just gained a level (`salmon`: 1)"},
+		{"salmon++", "`salmon` just gained a level (`salmon`: 2)"},
+		{"salmon++", "`salmon` just gained a level (`salmon`: 3)"},
+		{"salmon++", "`salmon` just gained a level (`salmon`: 4)"},
+		{"dams--", "`dams` just lost a life (`dams`: -1)"},
+		{"dams--", "`dams` just lost a life (`dams`: -2)"},
+		{"<@bot> karma", ""},
+		{"<@bot> karma top 2", "Here are the top 2 things: \n```4    salmon\n3    creek\n```\n"},
+		{"<@bot> karma worst 2", "Here are the worst 2 things: \n```-2   dams\n1    nettle\n```\n"},
+		{"<@U21355>++", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 1)"},
+		{"<@U21355>++", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 2)"},
+		{"<@U21355>++", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 3)"},
+		{"<@U21355>++", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 4)"},
+		{"<@U21355>++", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 5)"},
+		{"<@U21355>++", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 6)"},
+		{"<@bot> karma top 1", "Here are the top 1 things: \n```6    Bernard Tremblay\n```\n"},
+		{"don't++", "`don't` just gained a level (`don't`: 1)"},
+		{"under-the-bridge++", "`the-bridge` just gained a level (`the-bridge`: 1)"},
+		{"Jean-Michel++", "`Jean-Michel` just gained a level (`Jean-Michel`: 1)"},
+		{"+----------+", ""},
+		{"---", ""},
+		{"+++", ""},
+		{"<@bot> karma worst", ""},
+		{"<@bot> karma top", ""},
 	}
 
 	// Create a temp file that will serve as an invalid storage path
@@ -74,48 +72,19 @@ func TestKarmaMatchesAndAnswers(t *testing.T) {
 	k := plugins.NewKarma(storer)
 	k.UserInfoFinder = userInfoFinder
 
-	if assert.NotNil(t, k) {
-		// Attach the logger
-		var b strings.Builder
-		k.Logger = slackscot.NewSLogger(log.New(&b, "", 0), false)
+	assertplugin := assertplugin.New(t, "bot")
 
+	if assert.NotNil(t, k) {
 		for _, tc := range testCases {
 			t.Run(tc.text, func(t *testing.T) {
-				matches, answers := drivePlugin(tc.text, k)
-				assert.Equal(t, tc.expectedMatches, matches)
-				assert.Equal(t, tc.expectedAnswers, answers)
+				assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Text: tc.text}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+					if len(tc.expectedAnswer) > 0 {
+						return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], tc.expectedAnswer)
+					}
+
+					return assert.Empty(t, answers)
+				})
 			})
 		}
 	}
-}
-
-func drivePlugin(text string, k *plugins.Karma) (matches map[string]bool, answers map[string]string) {
-	matches = make(map[string]bool)
-	answers = make(map[string]string)
-
-	for i, h := range k.HearActions {
-		id := fmt.Sprintf("h[%d]", i)
-
-		msg := slackscot.IncomingMessage{NormalizedText: text, Msg: slack.Msg{Text: text}}
-		m := h.Match(&msg)
-		matches[id] = m
-
-		if m {
-			answers[id] = h.Answer(&msg).Text
-		}
-	}
-
-	for i, c := range k.Commands {
-		id := fmt.Sprintf("c[%d]", i)
-
-		msg := slackscot.IncomingMessage{NormalizedText: text, Msg: slack.Msg{Text: text}}
-		m := c.Match(&msg)
-		matches[id] = m
-
-		if m {
-			answers[id] = c.Answer(&msg).Text
-		}
-	}
-
-	return matches, answers
 }

--- a/plugins/ohmonday_test.go
+++ b/plugins/ohmonday_test.go
@@ -32,7 +32,7 @@ func TestSendValidGreetingEachTimeCalled(t *testing.T) {
 	pc.Set("channelIDs", []string{"channel1", "channel2"})
 
 	o, err := plugins.NewOhMonday(pc)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	sa := o.ScheduledActions[0]
 	var b strings.Builder
@@ -58,7 +58,7 @@ func TestDefaultAtTime(t *testing.T) {
 	pc.Set("channelIDs", "testChannel")
 
 	o, err := plugins.NewOhMonday(pc)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	sa := o.ScheduledActions[0]
 
 	assert.Equal(t, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "10:00"}, sa.Schedule)
@@ -68,7 +68,7 @@ func TestMissingChannelIDs(t *testing.T) {
 	pc := viper.New()
 
 	o, err := plugins.NewOhMonday(pc)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	sa := o.ScheduledActions[0]
 	var b strings.Builder
@@ -85,7 +85,7 @@ func TestEmptyChannels(t *testing.T) {
 	pc.Set("channelIDs", "")
 
 	o, err := plugins.NewOhMonday(pc)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	sa := o.ScheduledActions[0]
 	var b strings.Builder
@@ -103,7 +103,7 @@ func TestAtTimeOverride(t *testing.T) {
 	pc.Set("atTime", "11:00")
 
 	o, err := plugins.NewOhMonday(pc)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	sa := o.ScheduledActions[0]
 
 	assert.Equal(t, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "11:00"}, sa.Schedule)


### PR DESCRIPTION
## What is this about
Remove some redundant code in `karma_test` by migrating it to use `assertplugin`. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass