### PR TITLE
Add Support in assertplugin for Scheduled Actions Testing

### DIFF
--- a/chatdriver.go
+++ b/chatdriver.go
@@ -10,7 +10,7 @@ import (
 // for more advanced uses.
 type RealTimeMessageSender interface {
 	// SendNewMessage is the function that sends a new message to the specified channelID
-	SendNewMessage(message string, channelID string) (err error)
+	SendNewMessage(channelID string, message string) (err error)
 
 	// GetAPI is a function that returns the internal slack RTM
 	GetAPI() *slack.RTM
@@ -52,7 +52,7 @@ type slackRealTimeMsgSender struct {
 }
 
 // SendNewMessage sends a new message using the slack RTM api
-func (s *slackRealTimeMsgSender) SendNewMessage(message string, channelID string) (err error) {
+func (s *slackRealTimeMsgSender) SendNewMessage(channelID string, message string) (err error) {
 	m := s.rtm.NewOutgoingMessage(message, channelID)
 	s.rtm.SendMessage(m)
 

--- a/plugins/ohmonday.go
+++ b/plugins/ohmonday.go
@@ -95,6 +95,6 @@ func (o *OhMonday) sendGreeting(sender slackscot.RealTimeMessageSender) {
 		message := mondayPictures[selectionRandom.Intn(len(mondayPictures))]
 		o.Logger.Debugf("[%s] Sending morning greeting message [%s] to [%s]", OhMondayPluginName, message, c)
 
-		sender.SendNewMessage(message, c)
+		sender.SendNewMessage(c, message)
 	}
 }

--- a/test/capture/sendercaptor.go
+++ b/test/capture/sendercaptor.go
@@ -1,0 +1,34 @@
+package capture
+
+import (
+	"github.com/nlopes/slack"
+)
+
+// RealTimeSenderCaptor holds messages sent to it keyed
+// by channel ID
+type RealTimeSenderCaptor struct {
+	SentMessages map[string][]string
+}
+
+// NewSender returns a new initialized RealTimeSenderCaptor instance
+func NewRealTimeSender() (rtms *RealTimeSenderCaptor) {
+	rtms = new(RealTimeSenderCaptor)
+	rtms.SentMessages = make(map[string][]string)
+
+	return rtms
+}
+
+// SendNewMessage captures the details of a sent message (the message itself and the channel it's sent to)
+func (rtms *RealTimeSenderCaptor) SendNewMessage(channelID string, message string) (err error) {
+	if _, ok := rtms.SentMessages[channelID]; !ok {
+		rtms.SentMessages[channelID] = make([]string, 0)
+	}
+
+	rtms.SentMessages[channelID] = append(rtms.SentMessages[channelID], message)
+	return nil
+}
+
+// GetAPI always returns nil
+func (rtms *RealTimeSenderCaptor) GetAPI() (rtm *slack.RTM) {
+	return nil
+}

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.15.9"
+	VERSION = "1.16.0"
 )


### PR DESCRIPTION
## What is this about
Add support to `assertplugin` to drive a plugin's `ScheduledActions` and assert the expected messages are being sent. As usual, injected services are set on the plugin prior to driving the actions in case the plugin needs those (although the `RunsOnSchedule` validator currently doesn't have a hook to check for emoji reactions or files uploaded). 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass