### PR TITLE
Fix Some Godoc Typos and Bad Copy-Pasta 🍝

### DIFF
--- a/fileuploader.go
+++ b/fileuploader.go
@@ -27,7 +27,7 @@ type FileUploader interface {
 // UploadOption defines an option on a FileUploadParameters (i.e. upload on thread)
 type UploadOption func(params *slack.FileUploadParameters)
 
-// UploadInExistingThreadOption sets the file upload thread timestamp to an existing thread timestamp if
+// UploadInThreadOption sets the file upload thread timestamp to an existing thread timestamp if
 // the incoming message triggering this is on an existing thread
 func UploadInThreadOption(m *IncomingMessage) func(params *slack.FileUploadParameters) {
 	return func(p *slack.FileUploadParameters) {

--- a/store/datastoredb/datastoredb_internal_test.go
+++ b/store/datastoredb/datastoredb_internal_test.go
@@ -12,7 +12,7 @@ import (
 // mock of the datastore
 type mockDatastore struct {
 	mock.Mock
-	returnNoErrOnRepeatedKey bool   // If set, the mock will ignore any expected error set on a repeated invocation with the same key. Note that the key tracking is shared accross all functions
+	returnNoErrOnRepeatedKey bool   // If set, the mock will ignore any expected error set on a repeated invocation with the same key. Note that the key tracking is shared across all functions
 	lastKey                  string // Used to keep track of the last key in order to honor the returnNoErrOnRepeatedKey and *not* return an error on the second call with the same key
 }
 

--- a/test/assertplugin/assertplugin.go
+++ b/test/assertplugin/assertplugin.go
@@ -67,7 +67,7 @@ type ResultValidator func(t *testing.T, answers []*slackscot.Answer, emojis []st
 // if validation is successful and false otherwise (following the testify convention)
 type ResultWithUploadsValidator func(t *testing.T, answers []*slackscot.Answer, emojis []string, fileUploads []slack.FileUploadParameters) bool
 
-// ResultWithUploadsValidator is a function to do further validation of the messages sent by a slackscot.ScheduledAction.
+//  ScheduleResultValidator is a function to do further validation of the messages sent by a slackscot.ScheduledAction.
 // The messages sent during the execution of scheduled actions is given as a map of channel IDs to messages
 // sent on that channel. The return value is meant to be true if validation is successful and false otherwise
 // (following the testify convention)

--- a/test/assertplugin/assertplugin_test.go
+++ b/test/assertplugin/assertplugin_test.go
@@ -61,7 +61,7 @@ func newLittleTester() (mlt *myLittleTester) {
 	}
 
 	mlt.ScheduledActions = []slackscot.ScheduledActionDefinition{
-		slackscot.ScheduledActionDefinition{Schedule: schedule.Definition{Interval: 1, Unit: schedule.Minutes}, Description: "Check health", Action: healthStatus},
+		{Schedule: schedule.Definition{Interval: 1, Unit: schedule.Minutes}, Description: "Check health", Action: healthStatus},
 	}
 
 	return mlt

--- a/test/capture/emojireactioncaptor.go
+++ b/test/capture/emojireactioncaptor.go
@@ -14,7 +14,7 @@ type EmojiReactionCaptor struct {
 	Emojis    []string
 }
 
-// AddReaction adds an emoji reaction with the given named emoji to the given item
+// AddReaction captures the addition of an emoji reaction with the given named emoji to the given item
 func (e *EmojiReactionCaptor) AddReaction(name string, item slack.ItemRef) error {
 	if e.Channel == "" {
 		e.Channel = item.Channel

--- a/test/capture/fileuploadcaptor.go
+++ b/test/capture/fileuploadcaptor.go
@@ -13,7 +13,7 @@ type FileUploadCaptor struct {
 	currentID   int
 }
 
-// AddReaction adds an emoji reaction with the given named emoji to the given item
+// UploadFile tracks a file upload for post-execution validation
 func (f *FileUploadCaptor) UploadFile(params slack.FileUploadParameters) (file *slack.File, err error) {
 	f.FileUploads = append(f.FileUploads, params)
 

--- a/test/capture/sendercaptor.go
+++ b/test/capture/sendercaptor.go
@@ -10,7 +10,7 @@ type RealTimeSenderCaptor struct {
 	SentMessages map[string][]string
 }
 
-// NewSender returns a new initialized RealTimeSenderCaptor instance
+// NewRealTimeSender returns a new initialized RealTimeSenderCaptor instance
 func NewRealTimeSender() (rtms *RealTimeSenderCaptor) {
 	rtms = new(RealTimeSenderCaptor)
 	rtms.SentMessages = make(map[string][]string)

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.16.0"
+	VERSION = "1.16.1"
 )


### PR DESCRIPTION
## What is this about
Fix some recently introduced typos and bad copy-pasta in `godoc`. Since I'd consider wrong documentation a bug, I'm bumping the patch version number.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass