### PR TITLE
Convert triggerer_test to Use a Testify Mock Storer

### DIFF
--- a/plugins/storer_mock_test.go
+++ b/plugins/storer_mock_test.go
@@ -1,0 +1,45 @@
+package plugins_test
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+// mockStorer holds a mock to implement of mock of StringStorer
+type mockStorer struct {
+	mock.Mock
+}
+
+// GetString mocks an implementation of GetString
+func (ms *mockStorer) GetString(key string) (value string, err error) {
+	args := ms.Called(key)
+
+	return args.String(0), args.Error(1)
+}
+
+// PutString mocks an implementation of PutString
+func (ms *mockStorer) PutString(key string, value string) (err error) {
+	args := ms.Called(key, value)
+
+	return args.Error(0)
+}
+
+// DeleteString mocks an implementation of DeleteString
+func (ms *mockStorer) DeleteString(key string) (err error) {
+	args := ms.Called(key)
+
+	return args.Error(0)
+}
+
+// Scan mocks an implementation of Scan
+func (ms *mockStorer) Scan() (entries map[string]string, err error) {
+	args := ms.Called()
+
+	return args.Get(0).(map[string]string), args.Error(1)
+}
+
+// Close mocks an implementation of Close
+func (ms *mockStorer) Close() (err error) {
+	args := ms.Called()
+
+	return args.Error(0)
+}

--- a/plugins/triggerer_test.go
+++ b/plugins/triggerer_test.go
@@ -13,57 +13,13 @@ import (
 	"testing"
 )
 
-type memoryStringStorer struct {
-	triggers            map[string]string
-	returnErrorOnReads  bool
-	returnErrorOnWrites bool
-}
-
-func (m *memoryStringStorer) GetString(key string) (value string, err error) {
-	if m.returnErrorOnReads {
-		return "", fmt.Errorf("Mock error")
-	}
-
-	return m.triggers[key], nil
-}
-
-func (m *memoryStringStorer) PutString(key string, value string) (err error) {
-	if m.returnErrorOnWrites {
-		return fmt.Errorf("Mock error")
-	}
-
-	m.triggers[key] = value
-	return nil
-}
-
-func (m *memoryStringStorer) DeleteString(key string) (err error) {
-	if m.returnErrorOnWrites {
-		return fmt.Errorf("Mock error")
-	}
-
-	delete(m.triggers, key)
-	return nil
-}
-
-func (m *memoryStringStorer) Scan() (entries map[string]string, err error) {
-	if m.returnErrorOnReads {
-		return make(map[string]string), fmt.Errorf("Mock error")
-	}
-
-	return m.triggers, nil
-}
-
-func (m *memoryStringStorer) Close() (err error) {
-	return nil
-}
-
-func newInMemoryStorer() (m *memoryStringStorer) {
-	return &memoryStringStorer{triggers: make(map[string]string)}
-}
-
 func TestRegisterNewTrigger(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	triggerer := plugins.NewTriggerer(mockStorer)
+
+	mockStorer.On("GetString", "Sdeal with it").Return("", fmt.Errorf("not found"))
+	mockStorer.On("PutString", "Sdeal with it", "http://dealwithit.gif").Return(nil)
+	mockStorer.On("Scan").Return(map[string]string{"Sdeal with it": "http://dealwithit.gif"}, nil)
 
 	assertplugin := assertplugin.New(t, "bot")
 
@@ -95,8 +51,12 @@ func TestRegisterNewTrigger(t *testing.T) {
 }
 
 func TestRegisterNewMultilineReactionTrigger(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	triggerer := plugins.NewTriggerer(mockStorer)
+
+	mockStorer.On("GetString", "Sdeal with it").Return("", fmt.Errorf("not found"))
+	mockStorer.On("PutString", "Sdeal with it", "```{\n\"attributes\"=1.0\n}\n```").Return(nil)
+	mockStorer.On("Scan").Return(map[string]string{"Sdeal with it": "```{\n\"attributes\"=1.0\n}\n```"}, nil)
 
 	assertplugin := assertplugin.New(t, "bot")
 
@@ -115,8 +75,12 @@ func TestRegisterNewMultilineReactionTrigger(t *testing.T) {
 }
 
 func TestRegisterNewEmojiTrigger(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	triggerer := plugins.NewTriggerer(mockStorer)
+
+	mockStorer.On("GetString", "Edeal with it").Return("", fmt.Errorf("not found"))
+	mockStorer.On("PutString", "Edeal with it", "boom,cat").Return(nil)
+	mockStorer.On("Scan").Return(map[string]string{"Edeal with it": "boom,cat"}, nil)
 
 	assertplugin := assertplugin.New(t, "bot")
 
@@ -142,8 +106,8 @@ func TestRegisterNewEmojiTrigger(t *testing.T) {
 }
 
 func TestRegisterNewEmojiTriggerWithoutEmojis(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	triggerer := plugins.NewTriggerer(mockStorer)
 
 	assertplugin := assertplugin.New(t, "bot")
 
@@ -153,49 +117,44 @@ func TestRegisterNewEmojiTriggerWithoutEmojis(t *testing.T) {
 }
 
 func TestErrorGettingTriggersWhenReacting(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+	mockStorer.On("Scan").Return(map[string]string{}, fmt.Errorf("error getting triggers"))
+
+	triggerer := plugins.NewTriggerer(mockStorer)
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	// Register new trigger
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-	}) {
-		storer.returnErrorOnReads = true
-
-		// Validate trigger reaction is absent because of the error listing triggers
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Empty(t, answers) && assert.Empty(t, emojis)
-		})
-	}
+	// Validate trigger reaction is absent because of the error listing triggers
+	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Empty(t, answers) && assert.Empty(t, emojis)
+	})
 }
 
 // This case interacts directly with the hear action since it's a little harder to an error listing triggers when Answering if we go through the usual
 // MatchesAndAnswers flow. But since it's possible for no error to happen on Match and then an error to suddenly happen on Answer, we test that case here
 func TestErrorGettingTriggersWhenAnswering(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New(t, "bot")
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+	mockStorer.On("Scan").Return(map[string]string{}, fmt.Errorf("error getting triggers"))
 
-	// Register new trigger
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-	}) {
-		storer.returnErrorOnReads = true
+	triggerer := plugins.NewTriggerer(mockStorer)
+	var b strings.Builder
+	triggerer.Logger = slackscot.NewSLogger(log.New(&b, "", 0), false)
 
-		// Validate answer is empty because of the error listing triggers
-		hearAction := triggerer.HearActions[0]
-		assert.Nil(t, hearAction.Answer(&slackscot.IncomingMessage{NormalizedText: "deal with it", Msg: slack.Msg{Text: "deal with it"}}))
-	}
+	// Validate answer is empty because of the error listing triggers
+	hearAction := triggerer.HearActions[0]
+	assert.Nil(t, hearAction.Answer(&slackscot.IncomingMessage{NormalizedText: "deal with it", Msg: slack.Msg{Text: "deal with it"}}))
 }
 
 // This case interacts directly with the hear action since it's a little harder to simulate a case of Answer getting called without a matching trigger.
 // But since it can still happen (a race condition and a trigger being deleted between Match and Answer being called), we want to test it
 func TestNoReactionWhenNoTriggers(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+	mockStorer.On("Scan").Return(map[string]string{}, nil)
 
+	triggerer := plugins.NewTriggerer(mockStorer)
 	var b strings.Builder
 	triggerer.Logger = slackscot.NewSLogger(log.New(&b, "", 0), false)
 
@@ -204,8 +163,11 @@ func TestNoReactionWhenNoTriggers(t *testing.T) {
 }
 
 func TestNoAnswersAndNoEmojisWhenNoTriggers(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+	mockStorer.On("Scan").Return(map[string]string{}, nil)
+
+	triggerer := plugins.NewTriggerer(mockStorer)
 	assertplugin := assertplugin.New(t, "bot")
 
 	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
@@ -214,12 +176,14 @@ func TestNoAnswersAndNoEmojisWhenNoTriggers(t *testing.T) {
 }
 
 func TestErrorOnRegisterNewTrigger(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New(t, "bot")
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
 
-	// Have the storer return an error on write
-	storer.returnErrorOnWrites = true
+	mockStorer.On("GetString", "Sdeal with it").Return("", fmt.Errorf("not found"))
+	mockStorer.On("PutString", "Sdeal with it", "http://dealwithit.gif").Return(fmt.Errorf("Mock error"))
+
+	triggerer := plugins.NewTriggerer(mockStorer)
+	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger and get an error persisting it
 	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
@@ -229,111 +193,116 @@ func TestErrorOnRegisterNewTrigger(t *testing.T) {
 }
 
 func TestUpdateTrigger(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+
+	mockStorer.On("GetString", "Sdeal with it").Return("http://dealwithit.gif", nil)
+	mockStorer.On("PutString", "Sdeal with it", "http://betterdealwithit.gif").Return(nil)
+	mockStorer.On("Scan").Return(map[string]string{"Sdeal with it": "http://betterdealwithit.gif"}, nil)
+
+	triggerer := plugins.NewTriggerer(mockStorer)
 	assertplugin := assertplugin.New(t, "bot")
 
-	// Register new trigger
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://betterdealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Replaced standard trigger reaction for [`deal with it`] with [`http://betterdealwithit.gif`] (was [`http://dealwithit.gif`] previously)") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
-		if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://betterdealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Replaced standard trigger reaction for [`deal with it`] with [`http://betterdealwithit.gif`] (was [`http://dealwithit.gif`] previously)") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-		}) {
-			// Validate updated trigger reaction
-			assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-				return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://betterdealwithit.gif") && assertanswer.HasOptions(t, answers[0])
-			})
-		}
-	}
-}
-
-func TestUpdateEmojiTrigger(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New(t, "bot")
-
-	// Register new trigger
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :man-in-suit:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new emoji trigger [`deal with it` => :man-in-suit:]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-	}) {
-		if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :boom:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Replaced emoji trigger reaction for [`deal with it`] with [:boom:] (was [:man-in-suit:] previously)") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-		}) {
-			// Validate updated trigger reaction
-			assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-				return assert.Empty(t, answers) && assert.Contains(t, emojis, "boom")
-			})
-		}
-	}
-}
-
-func TestErrorOnUpdateTrigger(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
-	assertplugin := assertplugin.New(t, "bot")
-
-	// Register new trigger
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-	}) {
-		// Have the storer return an error on write
-		storer.returnErrorOnWrites = true
-
-		// Attempt to update trigger and expect error message
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://betterdealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error persisting standard trigger [`deal with it` => `http://betterdealwithit.gif`]: `Mock error`") &&
-				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
+		// Validate updated trigger reaction
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://betterdealwithit.gif") && assertanswer.HasOptions(t, answers[0])
 		})
 	}
 }
 
+func TestUpdateEmojiTrigger(t *testing.T) {
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+
+	mockStorer.On("GetString", "Edeal with it").Return("man-in-suit", nil)
+	mockStorer.On("PutString", "Edeal with it", "boom").Return(nil)
+	mockStorer.On("Scan").Return(map[string]string{"Edeal with it": "boom"}, nil)
+
+	triggerer := plugins.NewTriggerer(mockStorer)
+	assertplugin := assertplugin.New(t, "bot")
+
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :boom:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Replaced emoji trigger reaction for [`deal with it`] with [:boom:] (was [:man-in-suit:] previously)") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
+	}) {
+		// Validate updated trigger reaction
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+			return assert.Empty(t, answers) && assert.Contains(t, emojis, "boom")
+		})
+	}
+}
+
+func TestErrorOnUpdateTrigger(t *testing.T) {
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+
+	mockStorer.On("GetString", "Sdeal with it").Return("http://dealwithit.gif", nil)
+	mockStorer.On("PutString", "Sdeal with it", "http://betterdealwithit.gif").Return(fmt.Errorf("Mock error"))
+
+	triggerer := plugins.NewTriggerer(mockStorer)
+	assertplugin := assertplugin.New(t, "bot")
+
+	// Attempt to update trigger and expect error message
+	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://betterdealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error persisting standard trigger [`deal with it` => `http://betterdealwithit.gif`]: `Mock error`") &&
+			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
+	})
+}
+
 func TestDeleteTrigger(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+
+	mockStorer.On("GetString", "Sdeal with it").Return("http://dealwithit.gif", nil)
+	mockStorer.On("DeleteString", "Sdeal with it").Return(nil)
+	mockStorer.On("Scan").Return(map[string]string{}, nil)
+
+	triggerer := plugins.NewTriggerer(mockStorer)
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	// Register new trigger
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Deleted standard trigger [`deal with it` => `http://dealwithit.gif`]") &&
+			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
-		if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Deleted standard trigger [`deal with it` => `http://dealwithit.gif`]") &&
-				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-		}) {
-			// Validate no reaction
-			assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-				return assert.Empty(t, emojis) && assert.Empty(t, answers)
-			})
-		}
+		// Validate no reaction
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+			return assert.Empty(t, emojis) && assert.Empty(t, answers)
+		})
 	}
 }
 
 func TestDeleteEmojiTrigger(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+
+	mockStorer.On("GetString", "Edeal with it").Return("boom", nil)
+	mockStorer.On("DeleteString", "Edeal with it").Return(nil)
+	mockStorer.On("Scan").Return(map[string]string{}, nil)
+
+	triggerer := plugins.NewTriggerer(mockStorer)
 	assertplugin := assertplugin.New(t, "bot")
 
-	// Register new trigger
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :boom:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new emoji trigger [`deal with it` => :boom:]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
+	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> forget emoji trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Deleted emoji trigger [`deal with it` => :boom:]") &&
+			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
-		if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> forget emoji trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Deleted emoji trigger [`deal with it` => :boom:]") &&
-				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-		}) {
-			// Validate no reaction
-			assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-				return assert.Empty(t, emojis) && assert.Empty(t, answers)
-			})
-		}
+		// Validate no reaction
+		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+			return assert.Empty(t, emojis) && assert.Empty(t, answers)
+		})
 	}
 }
 
 func TestDeleteTriggerNotFound(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+
+	mockStorer.On("GetString", "Sdeal with it").Return("", fmt.Errorf("not found"))
+
+	triggerer := plugins.NewTriggerer(mockStorer)
 
 	assertplugin := assertplugin.New(t, "bot")
 
@@ -345,78 +314,64 @@ func TestDeleteTriggerNotFound(t *testing.T) {
 }
 
 func TestErrorOnDeleteTrigger(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+
+	mockStorer.On("GetString", "Sdeal with it").Return("http://dealwithit.gif", nil)
+	mockStorer.On("DeleteString", "Sdeal with it").Return(fmt.Errorf("Mock error"))
+
+	triggerer := plugins.NewTriggerer(mockStorer)
 	assertplugin := assertplugin.New(t, "bot")
 
-	// Register new trigger
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-	}) {
-		// Have the storer return an error on writes
-		storer.returnErrorOnWrites = true
-
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error removing standard trigger [`deal with it` => `http://dealwithit.gif`]: `Mock error`") &&
-				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-		})
-	}
+	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error removing standard trigger [`deal with it` => `http://dealwithit.gif`]: `Mock error`") &&
+			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
+	})
 }
 
 func TestListTriggers(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+
+	mockStorer.On("Scan").Return(map[string]string{"Sdeal with it": "http://dealwithit.gif", "Ssuddenly": "```{\n\"attributes\"=1.0\n}\n```"}, nil)
+
+	triggerer := plugins.NewTriggerer(mockStorer)
 	assertplugin := assertplugin.New(t, "bot")
 
-	// Register triggers
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-	}) && assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on suddenly with ```{\n\"attributes\"=1.0\n}\n```"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`suddenly` => ```{\n\"attributes\"=1.0\n}\n```]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-	}) {
-		// List triggers
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> list triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the current triggers: \n     • `deal with it` => `http://dealwithit.gif`\n     • `suddenly`     => ```{\n\"attributes\"=1.0\n}\n```\n\n") &&
-				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-		})
-	}
+	// List triggers
+	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> list triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the current triggers: \n     • `deal with it` => `http://dealwithit.gif`\n     • `suddenly`     => ```{\n\"attributes\"=1.0\n}\n```\n\n") &&
+			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
+	})
 }
 
 func TestListEmojiTriggers(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+
+	mockStorer.On("Scan").Return(map[string]string{"Edeal with it": "sunglasses", "Esuddenly": "scream,ghost"}, nil)
+
+	triggerer := plugins.NewTriggerer(mockStorer)
 	assertplugin := assertplugin.New(t, "bot")
 
-	// Register triggers
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on deal with it with :sunglasses:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new emoji trigger [`deal with it` => :sunglasses:]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-	}) && assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> emoji trigger on suddenly with :scream::ghost:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new emoji trigger [`suddenly` => :scream:, :ghost:]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-	}) {
-		// List triggers
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> list emoji triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the current emoji triggers: \n     • `deal with it` => :sunglasses:\n     • `suddenly`     => :scream:, :ghost:\n\n") &&
-				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-		})
-	}
+	// List triggers
+	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> list emoji triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the current emoji triggers: \n     • `deal with it` => :sunglasses:\n     • `suddenly`     => :scream:, :ghost:\n\n") &&
+			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
+	})
 }
 
 func TestErrorOnListTriggers(t *testing.T) {
-	storer := newInMemoryStorer()
-	triggerer := plugins.NewTriggerer(storer)
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+	mockStorer.On("Scan").Return(map[string]string{}, fmt.Errorf("Mock error"))
+
+	triggerer := plugins.NewTriggerer(mockStorer)
 	assertplugin := assertplugin.New(t, "bot")
 
-	// Register new trigger
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-	}) {
-		// Have the storer return an error on reads
-		storer.returnErrorOnReads = true
-
-		// List triggers
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> list triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-			return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error loading triggers:\n```Mock error```") &&
-				assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
-		})
-	}
+	// List triggers
+	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Text: "<@bot> list triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error loading triggers:\n```Mock error```") &&
+			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
+	})
 }


### PR DESCRIPTION
## What is this about
I was about to add some error tests to `karma_test` when I realized I could reuse my mock storer but since it was hand-coded, I thought I'd convert it first to a standard testify mock so I'd have more control over it. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass