### PR TITLE
Allow RTM Msg Senders to Use Message Options

### DIFF
--- a/chatdriver.go
+++ b/chatdriver.go
@@ -4,16 +4,12 @@ import (
 	"github.com/nlopes/slack"
 )
 
-// RealTimeMessageSender is implemented by any value that has the SendNewMessage and GetAPI method.
+// RealTimeMessageSender is implemented by any value that has the NewOutgoingMessage method.
 // The main purpose is a slight decoupling of the slack.RTM in order for plugins to be able to write
-// tests more easily if all they do is send new messages on a channel. GetAPI leaks the slack.RTM
-// for more advanced uses.
+// tests more easily if all they do is send new messages on a channel
 type RealTimeMessageSender interface {
-	// SendNewMessage is the function that sends a new message to the specified channelID
-	SendNewMessage(channelID string, message string) (err error)
-
-	// GetAPI is a function that returns the internal slack RTM
-	GetAPI() *slack.RTM
+	// NewOutgoingMessage is the function that sends a new message to the specified channelID
+	NewOutgoingMessage(text string, channelID string, options ...slack.RTMsgOption) *slack.OutgoingMessage
 }
 
 // messageSender is implemented by any value that has the SendMessage method. Note that the difference between the RealTimeMessageSender
@@ -44,23 +40,4 @@ type chatDriver interface {
 	messageDeleter
 	messageSender
 	messageUpdater
-}
-
-// slackRealTimeMsgSender is the default and main implementing type for the AdvancedMessageSender interface
-type slackRealTimeMsgSender struct {
-	rtm *slack.RTM
-}
-
-// SendNewMessage sends a new message using the slack RTM api
-func (s *slackRealTimeMsgSender) SendNewMessage(channelID string, message string) (err error) {
-	m := s.rtm.NewOutgoingMessage(message, channelID)
-	s.rtm.SendMessage(m)
-
-	return nil
-}
-
-// GetAPI returns the underlying slack RTM api. Beware that relying on this when writing a plugin
-// might mean complications in writing tests for it
-func (s *slackRealTimeMsgSender) GetAPI() *slack.RTM {
-	return s.rtm
 }

--- a/plugins/ohmonday.go
+++ b/plugins/ohmonday.go
@@ -90,11 +90,11 @@ func NewOhMonday(c *config.PluginConfig) (o *OhMonday, err error) {
 	return o, nil
 }
 
-func (o *OhMonday) sendGreeting(sender slackscot.RealTimeMessageSender) {
+func (o *OhMonday) sendGreeting() {
 	for _, c := range o.channels {
 		message := mondayPictures[selectionRandom.Intn(len(mondayPictures))]
 		o.Logger.Debugf("[%s] Sending morning greeting message [%s] to [%s]", OhMondayPluginName, message, c)
 
-		sender.SendNewMessage(c, message)
+		o.RealTimeMsgSender.NewOutgoingMessage(message, c)
 	}
 }

--- a/test/assertplugin/assertplugin_test.go
+++ b/test/assertplugin/assertplugin_test.go
@@ -82,8 +82,8 @@ func heyAnswerer(m *slackscot.IncomingMessage) *slackscot.Answer {
 	return &slackscot.Answer{Text: "hey wut?"}
 }
 
-func (mlt *myLittleTester) healthStatus(sender slackscot.RealTimeMessageSender) {
-	sender.SendNewMessage("test", "healthy")
+func (mlt *myLittleTester) healthStatus() {
+	mlt.RealTimeMsgSender.NewOutgoingMessage("healthy", "test")
 	mlt.FileUploader.UploadFile(slack.FileUploadParameters{Filename: "healthStatus.png", Filetype: "image/png", Title: "healthy"})
 }
 

--- a/test/capture/sendercaptor.go
+++ b/test/capture/sendercaptor.go
@@ -19,16 +19,12 @@ func NewRealTimeSender() (rtms *RealTimeSenderCaptor) {
 }
 
 // SendNewMessage captures the details of a sent message (the message itself and the channel it's sent to)
-func (rtms *RealTimeSenderCaptor) SendNewMessage(channelID string, message string) (err error) {
+// The returned OutgoingMessage has only the channel ID and text set on it
+func (rtms *RealTimeSenderCaptor) NewOutgoingMessage(text string, channelID string, options ...slack.RTMsgOption) *slack.OutgoingMessage {
 	if _, ok := rtms.SentMessages[channelID]; !ok {
 		rtms.SentMessages[channelID] = make([]string, 0)
 	}
 
-	rtms.SentMessages[channelID] = append(rtms.SentMessages[channelID], message)
-	return nil
-}
-
-// GetAPI always returns nil
-func (rtms *RealTimeSenderCaptor) GetAPI() (rtm *slack.RTM) {
-	return nil
+	rtms.SentMessages[channelID] = append(rtms.SentMessages[channelID], text)
+	return &slack.OutgoingMessage{Channel: channelID, Text: text}
 }

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.17.0"
+	VERSION = "1.18.0"
 )


### PR DESCRIPTION
## What is this about
This cleans up the `ScheduledAction` api and makes a few things simpler. Now `ScheduledActions` receive no parameters which means that to do something useful, that action should be written so it has access to its plugin services. While that seems like taking away something, it's actually more formalizing that a scheduled action can do anything it wants by using the plugin services (like upload a file maybe 🤷‍♂️). 

In the process, I also cleaned up the `RealTimeMessageSender` and made it so that `slack.RTM` implements it without wrapping. There's also no more `GetAPI` which was not something that I should have added in the first place. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass