### PR TITLE
Add SiloStringStorer with datastoredb Implementation

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -6,6 +6,17 @@ import (
 	"io"
 )
 
+// SiloStringStorer is implemented by any value that has the Get/Put/Delete/Scan and Closer methods
+// on string keys/values with a silo name.
+type SiloStringStorer interface {
+	io.Closer
+
+	GetSiloString(silo string, key string) (value string, err error)
+	PutSiloString(silo string, key string, value string) (err error)
+	DeleteSiloString(silo string, key string) (err error)
+	ScanSilo(silo string) (entries map[string]string, err error)
+}
+
 // StringStorer is implemented by any value that has the Get/Put/Delete/Scan and Closer methods
 // on string keys/values.
 type StringStorer interface {


### PR DESCRIPTION
## What is this about
Add new `SiloStringStorer` with support for siloed key/value storage. Also implement the new interface in `datastoredb`. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass