### PR TITLE
Implement SiloStringStorer in leveldb Implementation

### DIFF
--- a/store/leveldb_test.go
+++ b/store/leveldb_test.go
@@ -153,3 +153,31 @@ func TestPutGetScanAsString(t *testing.T) {
 
 	assert.Equal(t, map[string]string{"testKey": "value1"}, m)
 }
+
+func TestPutGetScanSiloString(t *testing.T) {
+	dir, err := ioutil.TempDir("", "tmpTest")
+	assert.Nil(t, err)
+	defer os.RemoveAll(dir)
+
+	var sstorer store.SiloStringStorer
+
+	sstorer, err = store.NewLevelDB("test", dir)
+	assert.NoError(t, err)
+	defer sstorer.Close()
+
+	err = sstorer.PutSiloString("ns1", "testKey", "value1")
+	assert.NoError(t, err)
+
+	_, err = sstorer.GetSiloString("otherns1", "testKey")
+	assert.Error(t, err)
+
+	v, err := sstorer.GetSiloString("ns1", "testKey")
+	assert.NoError(t, err)
+
+	assert.Equal(t, "value1", v)
+
+	m, err := sstorer.ScanSilo("ns1")
+	assert.Nil(t, err)
+
+	assert.Equal(t, map[string]string{"testKey": "value1"}, m)
+}

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.19.0"
+	VERSION = "1.20.0"
 )


### PR DESCRIPTION
## What is this about
Implement `SiloStringStorer` with `leveldb`. While that implementation isn't the main production one anymore, it remains useful for testing beyond what a mock storer can do so this is useful. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass