### PR TITLE
Change Karma Plugin to Track Per Channel Instead of Globally

### DIFF
--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -24,40 +24,44 @@ func (u userInfoFinder) GetUserInfo(userID string) (user *slack.User, err error)
 func TestKarmaMatchesAndAnswers(t *testing.T) {
 	testCases := []struct {
 		text           string
+		channel        string
 		expectedAnswer string
 	}{
-		{"creek++", "`creek` just gained a level (`creek`: 1)"},
-		{"creek--", "`creek` just lost a life (`creek`: 0)"},
-		{"the creek++", "`creek` just gained a level (`creek`: 1)"},
-		{"our creek++ is nice", "`creek` just gained a level (`creek`: 2)"},
-		{"our creek++ is really nice", "`creek` just gained a level (`creek`: 3)"},
-		{"oceans++", "`oceans` just gained a level (`oceans`: 1)"},
-		{"oceans++", "`oceans` just gained a level (`oceans`: 2)"},
-		{"nettle++", "`nettle` just gained a level (`nettle`: 1)"},
-		{"salmon++", "`salmon` just gained a level (`salmon`: 1)"},
-		{"salmon++", "`salmon` just gained a level (`salmon`: 2)"},
-		{"salmon++", "`salmon` just gained a level (`salmon`: 3)"},
-		{"salmon++", "`salmon` just gained a level (`salmon`: 4)"},
-		{"dams--", "`dams` just lost a life (`dams`: -1)"},
-		{"dams--", "`dams` just lost a life (`dams`: -2)"},
-		{"<@bot> karma", ""},
-		{"<@bot> karma top 2", "Here are the top 2 things: \n```4    salmon\n3    creek\n```\n"},
-		{"<@bot> karma worst 2", "Here are the worst 2 things: \n```-2   dams\n1    nettle\n```\n"},
-		{"<@U21355>++", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 1)"},
-		{"<@U21355>++", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 2)"},
-		{"<@U21355>++", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 3)"},
-		{"<@U21355>++", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 4)"},
-		{"<@U21355>++", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 5)"},
-		{"<@U21355>++", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 6)"},
-		{"<@bot> karma top 1", "Here are the top 1 things: \n```6    Bernard Tremblay\n```\n"},
-		{"don't++", "`don't` just gained a level (`don't`: 1)"},
-		{"under-the-bridge++", "`the-bridge` just gained a level (`the-bridge`: 1)"},
-		{"Jean-Michel++", "`Jean-Michel` just gained a level (`Jean-Michel`: 1)"},
-		{"+----------+", ""},
-		{"---", ""},
-		{"+++", ""},
-		{"<@bot> karma worst", ""},
-		{"<@bot> karma top", ""},
+		{"creek++", "Cgeneral", "`creek` just gained a level (`creek`: 1)"},
+		{"creek--", "Cgeneral", "`creek` just lost a life (`creek`: 0)"},
+		{"the creek++", "Cgeneral", "`creek` just gained a level (`creek`: 1)"},
+		{"our creek++ is nice", "Cgeneral", "`creek` just gained a level (`creek`: 2)"},
+		{"our creek++ is really nice", "Cgeneral", "`creek` just gained a level (`creek`: 3)"},
+		{"oceans++", "Cgeneral", "`oceans` just gained a level (`oceans`: 1)"},
+		{"oceans++", "Cgeneral", "`oceans` just gained a level (`oceans`: 2)"},
+		{"nettle++", "Cgeneral", "`nettle` just gained a level (`nettle`: 1)"},
+		{"salmon++", "Cgeneral", "`salmon` just gained a level (`salmon`: 1)"},
+		{"salmon++", "Cgeneral", "`salmon` just gained a level (`salmon`: 2)"},
+		{"salmon++", "Cgeneral", "`salmon` just gained a level (`salmon`: 3)"},
+		{"salmon++", "Cgeneral", "`salmon` just gained a level (`salmon`: 4)"},
+		{"dams--", "Cgeneral", "`dams` just lost a life (`dams`: -1)"},
+		{"dams--", "Cgeneral", "`dams` just lost a life (`dams`: -2)"},
+		{"<@bot> karma", "Cgeneral", ""},
+		{"<@bot> karma top 2", "Cgeneral", "Here are the top 2 things: \n```4    salmon\n3    creek\n```\n"},
+		{"<@bot> karma worst 2", "Cgeneral", "Here are the worst 2 things: \n```-2   dams\n1    nettle\n```\n"},
+		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 1)"},
+		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 2)"},
+		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 3)"},
+		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 4)"},
+		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 5)"},
+		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 6)"},
+		{"<@bot> karma top 1", "Cgeneral", "Here are the top 1 things: \n```6    Bernard Tremblay\n```\n"},
+		{"don't++", "Cgeneral", "`don't` just gained a level (`don't`: 1)"},
+		{"under-the-bridge++", "Cgeneral", "`the-bridge` just gained a level (`the-bridge`: 1)"},
+		{"Jean-Michel++", "Cgeneral", "`Jean-Michel` just gained a level (`Jean-Michel`: 1)"},
+		{"+----------+", "Cgeneral", ""},
+		{"---", "Cgeneral", ""},
+		{"+++", "Cgeneral", ""},
+		{"<@bot> karma worst", "Cgeneral", ""},
+		{"<@bot> karma top", "Cgeneral", ""},
+		{"salmon++", "Coceanlife", "`salmon` just gained a level (`salmon`: 1)"},
+		{"<@bot> karma top 1", "Coceanlife", "Here are the top 1 things: \n```1    salmon\n```\n"},
+		{"<@bot> karma top 1", "Cother", "Sorry, no recorded karma found :disappointed:"},
 	}
 
 	// Create a temp file that will serve as an invalid storage path
@@ -78,7 +82,7 @@ func TestKarmaMatchesAndAnswers(t *testing.T) {
 	if assert.NotNil(t, k) {
 		for _, tc := range testCases {
 			t.Run(tc.text, func(t *testing.T) {
-				assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Text: tc.text}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+				assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: tc.channel, Text: tc.text}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 					if len(tc.expectedAnswer) > 0 {
 						return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], tc.expectedAnswer)
 					}
@@ -92,9 +96,10 @@ func TestKarmaMatchesAndAnswers(t *testing.T) {
 
 func TestErrorStoringKarmaRecord(t *testing.T) {
 	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
 
-	mockStorer.On("GetString", "thing").Return("", fmt.Errorf("not found"))
-	mockStorer.On("PutString", "thing", "1").Return(fmt.Errorf("can't persist"))
+	mockStorer.On("GetSiloString", "myLittleChannel", "thing").Return("", fmt.Errorf("not found"))
+	mockStorer.On("PutSiloString", "myLittleChannel", "thing", "1").Return(fmt.Errorf("can't persist"))
 
 	var userInfoFinder userInfoFinder
 	k := plugins.NewKarma(mockStorer)
@@ -102,16 +107,17 @@ func TestErrorStoringKarmaRecord(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Text: "thing++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "thing++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers)
 	})
 }
 
 func TestInvalidStoredKarmaShouldResetValue(t *testing.T) {
 	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
 
-	mockStorer.On("GetString", "thing").Return("abc", nil)
-	mockStorer.On("PutString", "thing", "1").Return(nil)
+	mockStorer.On("GetSiloString", "myLittleChannel", "thing").Return("abc", nil)
+	mockStorer.On("PutSiloString", "myLittleChannel", "thing", "1").Return(nil)
 
 	var userInfoFinder userInfoFinder
 	k := plugins.NewKarma(mockStorer)
@@ -119,15 +125,16 @@ func TestInvalidStoredKarmaShouldResetValue(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Text: "thing++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "thing++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "`thing` just gained a level (`thing`: 1)")
 	})
 }
 
 func TestErrorGettingList(t *testing.T) {
 	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
 
-	mockStorer.On("Scan").Return(map[string]string{}, fmt.Errorf("can't load karma"))
+	mockStorer.On("ScanSilo", "myLittleChannel").Return(map[string]string{}, fmt.Errorf("can't load karma"))
 
 	var userInfoFinder userInfoFinder
 	k := plugins.NewKarma(mockStorer)
@@ -135,15 +142,16 @@ func TestErrorGettingList(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Text: "<@bot> karma top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get the top [1] things for you. If you must know, this happened: can't load karma")
 	})
 }
 
 func TestInvalidStoredKarmaValuesOnTopList(t *testing.T) {
 	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
 
-	mockStorer.On("Scan").Return(map[string]string{"thing": "abc"}, nil)
+	mockStorer.On("ScanSilo", "myLittleChannel").Return(map[string]string{"thing": "abc"}, nil)
 
 	var userInfoFinder userInfoFinder
 	k := plugins.NewKarma(mockStorer)
@@ -151,15 +159,16 @@ func TestInvalidStoredKarmaValuesOnTopList(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Text: "<@bot> karma top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get the top [1] things for you. If you must know, this happened: strconv.Atoi: parsing \"abc\": invalid syntax")
 	})
 }
 
 func TestLessItemsThanRequestedTopCountReturnsAllInOrder(t *testing.T) {
 	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
 
-	mockStorer.On("Scan").Return(map[string]string{"thing": "1", "bird": "2"}, nil)
+	mockStorer.On("ScanSilo", "myLittleChannel").Return(map[string]string{"thing": "1", "bird": "2"}, nil)
 
 	var userInfoFinder userInfoFinder
 	k := plugins.NewKarma(mockStorer)
@@ -167,15 +176,16 @@ func TestLessItemsThanRequestedTopCountReturnsAllInOrder(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Text: "<@bot> karma top 3"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma top 3"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the top 2 things: \n```2    bird\n1    thing\n```\n")
 	})
 }
 
 func TestLessItemsThanRequestedWorstCount(t *testing.T) {
 	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
 
-	mockStorer.On("Scan").Return(map[string]string{"thing": "1", "bird": "2"}, nil)
+	mockStorer.On("ScanSilo", "myLittleChannel").Return(map[string]string{"thing": "1", "bird": "2"}, nil)
 
 	var userInfoFinder userInfoFinder
 	k := plugins.NewKarma(mockStorer)
@@ -183,7 +193,7 @@ func TestLessItemsThanRequestedWorstCount(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Text: "<@bot> karma worst 3"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma worst 3"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the worst 2 things: \n```1    thing\n2    bird\n```\n")
 	})
 }

--- a/plugins/storer_mock_test.go
+++ b/plugins/storer_mock_test.go
@@ -16,9 +16,23 @@ func (ms *mockStorer) GetString(key string) (value string, err error) {
 	return args.String(0), args.Error(1)
 }
 
+// GetSiloString mocks an implementation of GetSiloString
+func (ms *mockStorer) GetSiloString(silo string, key string) (value string, err error) {
+	args := ms.Called(silo, key)
+
+	return args.String(0), args.Error(1)
+}
+
 // PutString mocks an implementation of PutString
 func (ms *mockStorer) PutString(key string, value string) (err error) {
 	args := ms.Called(key, value)
+
+	return args.Error(0)
+}
+
+// PutSiloString mocks an implementation of PutSiloString
+func (ms *mockStorer) PutSiloString(silo string, key string, value string) (err error) {
+	args := ms.Called(silo, key, value)
 
 	return args.Error(0)
 }
@@ -30,9 +44,23 @@ func (ms *mockStorer) DeleteString(key string) (err error) {
 	return args.Error(0)
 }
 
+// DeleteSiloString mocks an implementation of DeleteSiloString
+func (ms *mockStorer) DeleteSiloString(silo string, key string) (err error) {
+	args := ms.Called(silo, key)
+
+	return args.Error(0)
+}
+
 // Scan mocks an implementation of Scan
 func (ms *mockStorer) Scan() (entries map[string]string, err error) {
 	args := ms.Called()
+
+	return args.Get(0).(map[string]string), args.Error(1)
+}
+
+// ScanSilo mocks an implementation of ScanSilo
+func (ms *mockStorer) ScanSilo(silo string) (entries map[string]string, err error) {
+	args := ms.Called(silo)
 
 	return args.Get(0).(map[string]string), args.Error(1)
 }

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.20.0"
+	VERSION = "1.21.0"
 )


### PR DESCRIPTION
## What is this about
This changes how `karma` keeps track of things. Instead of being a single global map, it's now siloed by channel. This means that the previously recorded karma will get forgotten in the default silo/namespace. I think that given the non criticality of the feature, it's forgivable. 

Since it might still be fun to be able to see global entries, I'll probably add commands for `global karma top` and `global karma worst` soon. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass