### PR TITLE
🌍 Add GlobalSiloStringStorer Interface with leveldb and datastoredb Implementations 

### DIFF
--- a/store/leveldb.go
+++ b/store/leveldb.go
@@ -17,6 +17,10 @@ type LevelDB struct {
 	database *leveldb.DB
 }
 
+const (
+	siloKeyDelimiter = "\u00DA" // \xDA is not a valid UTF8 character so it serves fairly well as a delimiter for strings.
+)
+
 // NewLevelDB instantiates and open a new LevelDB instance backed by a leveldb database. If the
 // leveldb database doesn't exist, one is created
 func NewLevelDB(name string, storagePath string) (ldb *LevelDB, err error) {
@@ -45,64 +49,94 @@ func (ldb *LevelDB) Close() (err error) {
 
 // GetSiloString retrieves a value associated to the key in the given silo
 func (ldb *LevelDB) GetSiloString(silo string, key string) (value string, err error) {
-	val, err := ldb.Get([]byte(silo + key))
+	val, err := ldb.database.Get([]byte(EncodeKey(silo, key)), nil)
+	if err != nil {
+		return "", err
+	}
 
-	return string(val), err
+	return string(val), nil
 }
 
 // GetString retrieves a value associated to the key
 func (ldb *LevelDB) GetString(key string) (value string, err error) {
-	val, err := ldb.Get([]byte(key))
-
-	return string(val), err
+	return ldb.GetSiloString("", key)
 }
 
 // Get retrieves a value associated to the key
 func (ldb *LevelDB) Get(key []byte) (value []byte, err error) {
-	value, err = ldb.database.Get(key, nil)
+	val, err := ldb.GetSiloString("", string(key))
 	if err != nil {
 		return nil, err
 	}
 
-	return value, nil
+	return []byte(val), nil
 }
 
 // PutSiloString adds or updates a value associated to the key in the given silo
 func (ldb *LevelDB) PutSiloString(silo string, key string, value string) (err error) {
-	return ldb.Put([]byte(silo+key), []byte(value))
+	return ldb.database.Put([]byte(EncodeKey(silo, key)), []byte(value), nil)
 }
 
 // PutString adds or updates a value associated to the key
 func (ldb *LevelDB) PutString(key string, value string) (err error) {
-	return ldb.Put([]byte(key), []byte(value))
+	return ldb.PutSiloString("", key, value)
 }
 
 // Put adds or updates a value associated to the key
 func (ldb *LevelDB) Put(key []byte, value []byte) (err error) {
-	return ldb.database.Put(key, value, nil)
-}
-
-// DeleteString deletes an entry for a given key string
-func (ldb *LevelDB) DeleteString(key string) (err error) {
-	return ldb.Delete([]byte(key))
+	return ldb.PutSiloString("", string(key), string(value))
 }
 
 // DeleteSiloString deletes an entry for a given key string in the given silo
 func (ldb *LevelDB) DeleteSiloString(silo string, key string) (err error) {
-	return ldb.Delete([]byte(silo + key))
+	return ldb.database.Delete([]byte(EncodeKey(silo, key)), nil)
+}
+
+// DeleteString deletes an entry for a given key string
+func (ldb *LevelDB) DeleteString(key string) (err error) {
+	return ldb.DeleteSiloString("", key)
 }
 
 // Delete deletes an entry for a given key
 func (ldb *LevelDB) Delete(key []byte) (err error) {
-	return ldb.database.Delete(key, nil)
+	return ldb.DeleteSiloString("", string(key))
 }
 
 // Scan returns the complete set of key/values from the database
 func (ldb *LevelDB) Scan() (entries map[string]string, err error) {
+	return ldb.ScanSilo("")
+}
+
+// EncodeKey encodes a key with the silo name and the \xda character (not a valid utf8 character)
+func EncodeKey(silo string, key string) (encKey string) {
+	return SiloPrefix(silo) + key
+}
+
+// SiloPrefix returns the prefix for a key in the given silo
+func SiloPrefix(silo string) (prefix string) {
+	return silo + siloKeyDelimiter
+}
+
+// DecodeKey returns a logical key and silo given its raw key value
+func DecodeKey(rawKey string) (silo string, key string, err error) {
+	parts := strings.Split(rawKey, siloKeyDelimiter)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Invalid number of parts in key [%s], 2 expected but got [%d]", rawKey, len(parts))
+	}
+
+	return parts[0], parts[1], nil
+}
+
+// ScanSilo returns the complete set of key/values from the database in the given silo
+func (ldb *LevelDB) ScanSilo(silo string) (entries map[string]string, err error) {
 	entries = map[string]string{}
-	iter := ldb.database.NewIterator(nil, nil)
+	iter := ldb.database.NewIterator(util.BytesPrefix([]byte(SiloPrefix(silo))), nil)
 	for iter.Next() {
-		key := string(iter.Key())
+		_, key, err := DecodeKey(string(iter.Key()))
+		if err != nil {
+			return nil, err
+		}
+
 		value := string(iter.Value())
 		entries[key] = value
 	}
@@ -113,14 +147,23 @@ func (ldb *LevelDB) Scan() (entries map[string]string, err error) {
 	return entries, err
 }
 
-// ScanSilo returns the complete set of key/values from the database in the given silo
-func (ldb *LevelDB) ScanSilo(silo string) (entries map[string]string, err error) {
-	entries = map[string]string{}
-	iter := ldb.database.NewIterator(util.BytesPrefix([]byte(silo)), nil)
+// GlobalScan returns the complete set of key/values from the database for all silos
+func (ldb *LevelDB) GlobalScan() (entries map[string]map[string]string, err error) {
+	entries = make(map[string]map[string]string)
+	iter := ldb.database.NewIterator(nil, nil)
 	for iter.Next() {
-		key := strings.TrimPrefix(string(iter.Key()), silo)
+		silo, key, err := DecodeKey(string(iter.Key()))
+		if err != nil {
+			return nil, err
+		}
+
 		value := string(iter.Value())
-		entries[key] = value
+
+		if _, ok := entries[silo]; !ok {
+			entries[silo] = make(map[string]string)
+		}
+
+		entries[silo][key] = value
 	}
 
 	iter.Release()

--- a/store/store.go
+++ b/store/store.go
@@ -6,6 +6,13 @@ import (
 	"io"
 )
 
+// GlobalScan is implemented by any value that has all the SiloStringStorer methods
+// and the GlobalScanSilo method
+type GlobalSiloStringStorer interface {
+	SiloStringStorer
+	GlobalScan() (entries map[string]map[string]string, err error)
+}
+
 // SiloStringStorer is implemented by any value that has the Get/Put/Delete/Scan and Closer methods
 // on string keys/values with a silo name.
 type SiloStringStorer interface {

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.21.0"
+	VERSION = "1.22.0"
 )


### PR DESCRIPTION
## What is this about
Add `GlobalSiloStringStorer` to allow global scans returning all db contents regardless of silo name. 
Also made the key storage in `leveldb` more robust by using a delimiter (`\u00DA`) which isn't a valid utf8 character. 

Importantly, the new interface comes with implementations in `datastoredb` and `leveldb`. Coming next, the `karma` plugin will use `GlobalSiloStringStorer` to support new commands for global karma retrieval. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass