### PR TITLE
Fix Emoji Banner Allowed Word Lenght in Error Message

### DIFF
--- a/plugins/emojibanner.go
+++ b/plugins/emojibanner.go
@@ -24,6 +24,7 @@ const (
 const (
 	// EmojiBannerPluginName holds identifying name for the emoji banner plugin
 	EmojiBannerPluginName = "emojiBanner"
+	bannerMaxWordLength   = 4
 )
 
 // EmojiBannerMaker holds the plugin data for the emoji banner maker plugin
@@ -124,15 +125,15 @@ func validateAndRenderEmoji(message string, regex *regexp.Regexp, renderer *figl
 			word := parameters[0]
 			emoji := parameters[1]
 
-			if len(word) < 5 {
+			if len(word) <= bannerMaxWordLength {
 				return renderBanner(word, emoji, renderer, options)
 			}
 
-			return &slackscot.Answer{Text: "`Wrong usage` (word *longer* than `5` characters): emoji banner `<word of 5 characters or less>` `<emoji>`"}
+			return &slackscot.Answer{Text: fmt.Sprintf("`Wrong usage` (word *longer* than `%d` characters): emoji banner `<word of 5 characters or less>` `<emoji>`", bannerMaxWordLength)}
 		}
 	}
 
-	return &slackscot.Answer{Text: "`Wrong usage`: emoji banner `<word of 5 characters or less>` `<emoji>`"}
+	return &slackscot.Answer{Text: fmt.Sprintf("`Wrong usage`: emoji banner `<word of %d characters or less>` `<emoji>`", bannerMaxWordLength)}
 }
 
 func renderBanner(word, emoji string, renderer *figlet4go.AsciiRender, options *figlet4go.RenderOptions) *slackscot.Answer {

--- a/plugins/emojibanner_test.go
+++ b/plugins/emojibanner_test.go
@@ -48,11 +48,11 @@ func TestEmojiBannerGenerationWithWrongUsage(t *testing.T) {
 	assertplugin := assertplugin.New(t, "robert")
 
 	assertplugin.AnswersAndReacts(&ebm.Plugin, &slack.Msg{Text: "<@robert> emoji banner"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "`Wrong usage`: emoji banner `<word of 5 characters or less>` `<emoji>`")
+		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "`Wrong usage`: emoji banner `<word of 4 characters or less>` `<emoji>`")
 	})
 
 	assertplugin.AnswersAndReacts(&ebm.Plugin, &slack.Msg{Text: "<@robert> emoji banner cats"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "`Wrong usage`: emoji banner `<word of 5 characters or less>` `<emoji>`")
+		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "`Wrong usage`: emoji banner `<word of 4 characters or less>` `<emoji>`")
 	})
 }
 
@@ -65,8 +65,8 @@ func TestEmojiBannerGenerationWithLongWord(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "robert")
 
-	assertplugin.AnswersAndReacts(&ebm.Plugin, &slack.Msg{Text: "<@robert> emoji banner testing :bug:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "`Wrong usage` (word *longer* than `5` characters): emoji banner `<word of 5 characters or less>` `<emoji>`")
+	assertplugin.AnswersAndReacts(&ebm.Plugin, &slack.Msg{Text: "<@robert> emoji banner hello :bug:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "`Wrong usage` (word *longer* than `4` characters): emoji banner `<word of 5 characters or less>` `<emoji>`")
 	})
 }
 

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.22.0"
+	VERSION = "1.22.1"
 )


### PR DESCRIPTION
## What is this about
The message said words longer than `5` were disallowed but it was actually messages longer than 4. This fixes that erroneous message. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass