### PR TITLE
🌓 Add Global Karma Commands to Karma Plugin

### DIFF
--- a/plugins/storer_mock_test.go
+++ b/plugins/storer_mock_test.go
@@ -65,6 +65,13 @@ func (ms *mockStorer) ScanSilo(silo string) (entries map[string]string, err erro
 	return args.Get(0).(map[string]string), args.Error(1)
 }
 
+// GlobalScan mocks an implementation of GlobalScan
+func (ms *mockStorer) GlobalScan() (entries map[string]map[string]string, err error) {
+	args := ms.Called()
+
+	return args.Get(0).(map[string]map[string]string), args.Error(1)
+}
+
 // Close mocks an implementation of Close
 func (ms *mockStorer) Close() (err error) {
 	args := ms.Called()

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.22.2"
+	VERSION = "1.23.0"
 )


### PR DESCRIPTION
## What is this about
This adds two new commands to the `karma` plugin:
`karma global top <count>` and
`karma global worst <count>`

Hopefully it's intuitive as to what they do but it's basically the same as the top/worst commands except that the results include karma across all channels. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass