### PR TITLE
Add Karma Clear Command to Clear Channel Karma

### DIFF
--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.24.0"
+	VERSION = "1.25.0"
 )


### PR DESCRIPTION
## What is this about
Adds a `karma clear` command to clear a channel's recorded karma. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass