### PR TITLE
🐲 Fix Broken Global Scan Implementation in datastoredb

### DIFF
--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.28.0"
+	VERSION = "1.28.1"
 )


### PR DESCRIPTION
## What is this about
I misunderstood the `datastore` api and I thought that not providing a `namespace` would imply querying _all_ namespaces. If I had thought about the default/zero value of the namespace in `Query`, I wouldn't have made that stupid mistake.

Anyway, the correct way to do this is to do a key-only scan of `__namespace__` to get the list of namespaces and then query each one. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass