### PR TITLE
🚫◻️ Disallow Extra Space Between Thing and Symbol Except for User IDs

### DIFF
--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -49,6 +49,7 @@ func TestKarmaMatchesAndAnswers(t *testing.T) {
 		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 5)"},
 		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 6)"},
 		{"<@U21355> ++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 7)"},
+		{"thing ++", "Cgeneral", ""},
 		{"don't++", "Cgeneral", "`don't` just gained a level (`don't`: 1)"},
 		{"under-the-bridge++", "Cgeneral", "`the-bridge` just gained a level (`the-bridge`: 1)"},
 		{"Jean-Michel++", "Cgeneral", "`Jean-Michel` just gained a level (`Jean-Michel`: 1)"},

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.28.1"
+	VERSION = "1.28.2"
 )


### PR DESCRIPTION
## What is this about
By relaxing the regex and allowing an extra space between a user id and the increment/decrement `<@user> ++`, it allowed it for any word. I knew and I thought about this but it turns out it's more annoying than I anticipated. 

The regex is starting to look a bit crazy (not too crazy but it's not a delight to the eye) but it's still reasonable. The worse is having two different matching groups but it also helps keeping the expression for each one more readable so maybe it's even a net win. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass