### PR TITLE
😇 Make Count Optional in Top/Worst Karma Commands

### DIFF
--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.28.2"
+	VERSION = "1.29.0"
 )


### PR DESCRIPTION
## What is this about
This makes the count parameter optional when requesting a top/worst listing. Most people didn't want to have to think about a number of items to list so it makes sense to allow it and have default. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass