### PR TITLE
🏷 Add Managed Plugin Command Namespacing

### DIFF
--- a/plugins/karma.go
+++ b/plugins/karma.go
@@ -41,10 +41,10 @@ var globalWorstRanker ranker
 var worstRanker ranker
 
 func init() {
-	globalTopRanker = ranker{name: "global top", regexp: regexp.MustCompile("(?i)\\A(karma global top)+(?:\\s+(\\d*))*\\z"), banner: "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :trophy: *Global Top* :trophy: `**•-:¦:-•:*'\"\"*:•-:¦:-`", rankRenderer: topIconRenderer, scanner: scanGlobalKarma, sorter: sortTop}
-	topRanker = ranker{name: "top", regexp: regexp.MustCompile("(?i)\\A(karma top)+(?:\\s+(\\d*))*\\z"), banner: "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :trophy: *Top* :trophy: `**•-:¦:-•:*'\"\"*:•-:¦:-`", rankRenderer: topIconRenderer, scanner: scanChannelKarma, sorter: sortTop}
-	globalWorstRanker = ranker{name: "global worst", regexp: regexp.MustCompile("(?i)\\A(karma global worst)+(?:\\s+(\\d*))*\\z"), banner: "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :space_invader: *Global Worst* :space_invader: `**•-:¦:-•:*'\"\"*:•-:¦:-`", rankRenderer: worstIconRenderer, scanner: scanGlobalKarma, sorter: sortWorst}
-	worstRanker = ranker{name: "worst", regexp: regexp.MustCompile("(?i)\\A(karma worst)+(?:\\s+(\\d*))*\\z"), banner: "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :space_invader: *Worst* :space_invader: `**•-:¦:-•:*'\"\"*:•-:¦:-`", rankRenderer: worstIconRenderer, scanner: scanChannelKarma, sorter: sortWorst}
+	globalTopRanker = ranker{name: "global top", regexp: regexp.MustCompile("(?i)\\A(global top)+(?:\\s+(\\d*))*\\z"), banner: "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :trophy: *Global Top* :trophy: `**•-:¦:-•:*'\"\"*:•-:¦:-`", rankRenderer: topIconRenderer, scanner: scanGlobalKarma, sorter: sortTop}
+	topRanker = ranker{name: "top", regexp: regexp.MustCompile("(?i)\\A(top)+(?:\\s+(\\d*))*\\z"), banner: "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :trophy: *Top* :trophy: `**•-:¦:-•:*'\"\"*:•-:¦:-`", rankRenderer: topIconRenderer, scanner: scanChannelKarma, sorter: sortTop}
+	globalWorstRanker = ranker{name: "global worst", regexp: regexp.MustCompile("(?i)\\A(global worst)+(?:\\s+(\\d*))*\\z"), banner: "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :space_invader: *Global Worst* :space_invader: `**•-:¦:-•:*'\"\"*:•-:¦:-`", rankRenderer: worstIconRenderer, scanner: scanGlobalKarma, sorter: sortWorst}
+	worstRanker = ranker{name: "worst", regexp: regexp.MustCompile("(?i)\\A(worst)+(?:\\s+(\\d*))*\\z"), banner: "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :space_invader: *Worst* :space_invader: `**•-:¦:-•:*'\"\"*:•-:¦:-`", rankRenderer: worstIconRenderer, scanner: scanChannelKarma, sorter: sortWorst}
 }
 
 // NewKarma creates a new instance of the Karma plugin
@@ -64,41 +64,41 @@ func NewKarma(strStorer store.GlobalSiloStringStorer) (karma *Karma) {
 		{
 			Hidden:      false,
 			Match:       matchKarmaTopReport,
-			Usage:       "karma top [count]",
+			Usage:       "top [count]",
 			Description: fmt.Sprintf("Return the top things ever recorded in this channel (default of %d items)", defaultItemCount),
 			Answer:      k.answerKarmaTop,
 		},
 		{
 			Hidden:      false,
 			Match:       matchKarmaWorstReport,
-			Usage:       "karma worst [count]",
+			Usage:       "worst [count]",
 			Description: fmt.Sprintf("Return the worst things ever recorded in this channel (default of %d items)", defaultItemCount),
 			Answer:      k.answerKarmaWorst,
 		},
 		{
 			Hidden:      false,
 			Match:       matchGlobalKarmaTopReport,
-			Usage:       "karma global top [count]",
+			Usage:       "global top [count]",
 			Description: fmt.Sprintf("Return the top things ever over all channels (default of %d items)", defaultItemCount),
 			Answer:      k.answerGlobalKarmaTop,
 		},
 		{
 			Hidden:      false,
 			Match:       matchGlobalKarmaWorstReport,
-			Usage:       "karma global worst [count]",
+			Usage:       "global worst [count]",
 			Description: fmt.Sprintf("Return the worst things ever over all channels (default of %d items)", defaultItemCount),
 			Answer:      k.answerGlobalKarmaWorst,
 		},
 		{
 			Hidden:      false,
-			Match:       matchClearKarma,
-			Usage:       "karma reset",
+			Match:       matchKarmaReset,
+			Usage:       "reset",
 			Description: "Resets all recorded karma for the current channel",
 			Answer:      k.clearChannelKarma,
 		},
 	}
 
-	k.Plugin = slackscot.Plugin{Name: KarmaPluginName, Commands: commands, HearActions: hearActions}
+	k.Plugin = slackscot.Plugin{Name: KarmaPluginName, NamespaceCommands: true, Commands: commands, HearActions: hearActions}
 	k.karmaStorer = strStorer
 
 	return k
@@ -111,33 +111,33 @@ func matchKarmaRecord(m *slackscot.IncomingMessage) bool {
 }
 
 // matchKarmaTopReport returns true if the message matches a request for top karma with
-// a message such as "karma top <count>"
+// a message such as "top <count>"
 func matchKarmaTopReport(m *slackscot.IncomingMessage) bool {
 	return topRanker.regexp.MatchString(m.NormalizedText)
 }
 
 // matchKarmaWorstReport returns true if the message matches a request for the worst karma with
-// a message such as "karma worst <count>"
+// a message such as "worst <count>"
 func matchKarmaWorstReport(m *slackscot.IncomingMessage) bool {
 	return worstRanker.regexp.MatchString(m.NormalizedText)
 }
 
 // matchGlobalKarmaTopReport returns true if the message matches a request for top global karma with
-// a message such as "global karma top <count>"
+// a message such as "global top <count>"
 func matchGlobalKarmaTopReport(m *slackscot.IncomingMessage) bool {
 	return globalTopRanker.regexp.MatchString(m.NormalizedText)
 }
 
 // matchGlobalKarmaWorstReport returns true if the message matches a request for the worst global karma with
-// a message such as "global karma worst <count>"
+// a message such as "global worst <count>"
 func matchGlobalKarmaWorstReport(m *slackscot.IncomingMessage) bool {
 	return globalWorstRanker.regexp.MatchString(m.NormalizedText)
 }
 
-// matchClearKarma returns true if the message matches a request for resetting karma with a
-// message such as "karma reset"
-func matchClearKarma(m *slackscot.IncomingMessage) bool {
-	return strings.HasPrefix(m.NormalizedText, "karma reset")
+// matchKarmaReset returns true if the message matches a request for resetting karma with a
+// message such as "reset"
+func matchKarmaReset(m *slackscot.IncomingMessage) bool {
+	return strings.HasPrefix(m.NormalizedText, "reset")
 }
 
 // recordKarma records a karma increase or decrease and answers with a message including

--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -57,10 +57,10 @@ func TestKarmaMatchesAndAnswers(t *testing.T) {
 		{"---", "Cgeneral", ""},
 		{"+++", "Cgeneral", ""},
 		{"salmon++", "Coceanlife", "`salmon` just gained a level (`salmon`: 1)"},
-		{"<@bot> karma top 1", "Cother", "Sorry, no recorded karma found :disappointed:"},
+		{"<@bot> top 1", "Cother", "Sorry, no recorded karma found :disappointed:"},
 		{"dams--", "Coceanlife", "`dams` just lost a life (`dams`: -1)"},
-		{"<@bot> karma reset", "Coceanlife", "karma all cleared :white_check_mark::boom:"},
-		{"<@bot> karma top 1", "Coceanlife", "Sorry, no recorded karma found :disappointed:"},
+		{"<@bot> reset", "Coceanlife", "karma all cleared :white_check_mark::boom:"},
+		{"<@bot> top 1", "Coceanlife", "Sorry, no recorded karma found :disappointed:"},
 	}
 
 	// Create a temp file that will serve as an invalid storage path
@@ -141,7 +141,7 @@ func TestErrorGettingList(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get the top [1] things for you. If you must know, this happened: can't load karma")
 	})
 }
@@ -158,7 +158,7 @@ func TestErrorGettingKarmaWhenResetting(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma reset"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> reset"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get delete karma for channel [myLittleChannel] for you. If you must know, this happened: can't load karma")
 	})
 }
@@ -176,7 +176,7 @@ func TestErrorDeletingKarmaWhenResetting(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma reset"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> reset"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get delete karma for channel [myLittleChannel] for you. If you must know, this happened: can't delete")
 	})
 }
@@ -193,7 +193,7 @@ func TestErrorGettingGlobalList(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "otherChan", Text: "<@bot> karma global top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "otherChan", Text: "<@bot> global top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get the global top [1] things for you. If you must know, this happened: can't load karma")
 	})
 }
@@ -210,7 +210,7 @@ func TestInvalidStoredKarmaValuesOnTopList(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get the top [1] things for you. If you must know, this happened: strconv.Atoi: parsing \"abc\": invalid syntax")
 	})
 }
@@ -227,7 +227,7 @@ func TestInvalidSingleStoredKarmaValuesOnGlobalTopList(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "otherChannel", Text: "<@bot> karma global top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "otherChannel", Text: "<@bot> global top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get the global top [1] things for you. If you must know, this happened: strconv.Atoi: parsing \"abc\": invalid syntax")
 	})
 }
@@ -244,7 +244,7 @@ func TestInvalidSingleStoredKarmaValuesOnGlobalWorstList(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "otherChannel", Text: "<@bot> karma global worst 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "otherChannel", Text: "<@bot> global worst 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get the global worst [1] things for you. If you must know, this happened: strconv.Atoi: parsing \"abc\": invalid syntax")
 	})
 }
@@ -261,7 +261,7 @@ func TestLessItemsThanRequestedTopCountReturnsAllInOrder(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma top 3"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top 3"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :trophy: *Top* :trophy: `**•-:¦:-•:*'\"\"*:•-:¦:-`", false, false), nil, nil),
@@ -284,7 +284,7 @@ func TestGlobalTopFormattingAndKarmaMerging(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma global top 2"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> global top 2"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :trophy: *Global Top* :trophy: `**•-:¦:-•:*'\"\"*:•-:¦:-`", false, false), nil, nil),
@@ -307,7 +307,7 @@ func TestTopFormatting(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma top 4"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top 4"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :trophy: *Top* :trophy: `**•-:¦:-•:*'\"\"*:•-:¦:-`", false, false), nil, nil),
@@ -334,7 +334,7 @@ func TestTopListingWithoutRequestedCount(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma top"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :trophy: *Top* :trophy: `**•-:¦:-•:*'\"\"*:•-:¦:-`", false, false), nil, nil),
@@ -363,7 +363,7 @@ func TestGlobalTopListingWithoutRequestedCount(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma global top"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> global top"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :trophy: *Global Top* :trophy: `**•-:¦:-•:*'\"\"*:•-:¦:-`", false, false), nil, nil),
@@ -392,7 +392,7 @@ func TestGlobalWorstFormattingAndKarmaMerging(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma global worst 2"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> global worst 2"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :space_invader: *Global Worst* :space_invader: `**•-:¦:-•:*'\"\"*:•-:¦:-`", false, false), nil, nil),
@@ -415,7 +415,7 @@ func TestWorstFormatting(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma worst 4"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> worst 4"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :space_invader: *Worst* :space_invader: `**•-:¦:-•:*'\"\"*:•-:¦:-`", false, false), nil, nil),
@@ -442,7 +442,7 @@ func TestGlobalWorstListingWithoutRequestedCount(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma global worst"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> global worst"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :space_invader: *Global Worst* :space_invader: `**•-:¦:-•:*'\"\"*:•-:¦:-`", false, false), nil, nil),
@@ -471,7 +471,7 @@ func TestWorstListingWithoutRequestedCount(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma worst"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> worst"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :space_invader: *Worst* :space_invader: `**•-:¦:-•:*'\"\"*:•-:¦:-`", false, false), nil, nil),
@@ -500,7 +500,7 @@ func TestLessItemsThanRequestedWorstCount(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> karma worst 3"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> worst 3"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", "`-:¦:-•:*'\"\"*:•.-:¦:-•**` :space_invader: *Worst* :space_invader: `**•-:¦:-•:*'\"\"*:•-:¦:-`", false, false), nil, nil),

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.29.1"
+	VERSION = "1.30.0"
 )


### PR DESCRIPTION
## What is this about
Add managed plugin command namespacing. Plugins don't have it set by default but if desired, they can have `NamespaceCommands` set to `true` for `slackscot` to check for commands to match the plugin name. This can also be disabled at runtime with`OptionNoPluginNamespacing` if, for example, an instance of slackscot is meant to run a single plugin and namespacing is superfluous. 

The `karma` opts-in toe `NamespaceCommands` and shows how plugins should expect a normalized text stripped of the namespace. `Slackscot` manages stripping it if namespacing is enabled at runtime. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass