### PR TITLE
🕸 Deprecate slackscot.NewSlackscot In Favor of slackscot.New

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ func main() {
 		options = append(options, slackscot.OptionLogfile(*logfile))
 	}
 
-	youppi, err := slackscot.NewSlackscot("youppi", v, options...)
+	youppi, err := slackscot.New("youppi", v, options...)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/help_internal_test.go
+++ b/help_internal_test.go
@@ -39,7 +39,7 @@ func newPluginWithActionsOfAllTypes() (p *Plugin) {
 }
 
 func TestHelpWithNamespacingEnabled(t *testing.T) {
-	s, err := NewSlackscot("robert", config.NewViperWithDefaults())
+	s, err := New("robert", config.NewViperWithDefaults())
 	s.RegisterPlugin(newPluginWithActionsOfAllTypes())
 
 	require.NoError(t, err)
@@ -62,7 +62,7 @@ func TestHelpWithNamespacingEnabled(t *testing.T) {
 }
 
 func TestHelpWithNamespacingDisabled(t *testing.T) {
-	s, err := NewSlackscot("robert", config.NewViperWithDefaults(), OptionNoPluginNamespacing())
+	s, err := New("robert", config.NewViperWithDefaults(), OptionNoPluginNamespacing())
 	s.RegisterPlugin(newPluginWithActionsOfAllTypes())
 
 	require.NoError(t, err)

--- a/slackscot.go
+++ b/slackscot.go
@@ -223,7 +223,14 @@ func OptionLogfile(logfile *os.File) func(*Slackscot) {
 }
 
 // NewSlackscot creates a new slackscot from an array of plugins and a name
+//
+// Deprecated: Use New instead. Will be removed in 2.0.0
 func NewSlackscot(name string, v *viper.Viper, options ...Option) (s *Slackscot, err error) {
+	return New(name, v, options...)
+}
+
+// New creates a new slackscot from an array of plugins and a name
+func New(name string, v *viper.Viper, options ...Option) (s *Slackscot, err error) {
 	s = new(Slackscot)
 
 	s.triggeringMsgToResponse, err = lru.NewARC(v.GetInt(config.ResponseCacheSizeKey))

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -749,7 +749,7 @@ func runSlackscotWithIncomingEvents(t *testing.T, v *viper.Viper, plugin *Plugin
 	var userInfoFinder userInfoFinder
 	var emojiReactor emojiReactor
 
-	s, err := NewSlackscot("chickadee", v, options...)
+	s, err := New("chickadee", v, options...)
 	s.RegisterPlugin(plugin)
 
 	assert.Nil(t, err)

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.30.3"
+	VERSION = "1.31.0"
 )


### PR DESCRIPTION
## What is this about
Replace `slackscot.NewSlackscot` by `slackscot.New` (reads better and is more idiomatic). `NewSlackscot` remains for backward compatibility but will be gone when switching to `2.0.0`.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass