### PR TITLE
Fluent api for plugin creation

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -22,7 +22,8 @@ a quick one could look like:
 				WithAnswerer(func(m *slackscot.IncomingMessage) *slackscot.Answer {
 					return &slackscot.Answer{Text: fmt.Sprintf(":white_check_mark: It's ready for you!")}
 				}).
-				Build()).
+				Build()
+			 ).
 			WithHearAction(actions.NewHearAction().
 				Hidden().
 				WithMatcher(func(m *slackscot.IncomingMessage) bool {
@@ -34,7 +35,9 @@ a quick one could look like:
 				Build()
 		     ).
 			WithScheduledAction(actions.NewScheduledAction().
-				...
+				WithSchedule(schedule.New().Every(time.Monday.string()).AtTime("10:00").Build()).
+				WithDescription("Start the week off").
+				WithAction(weeklyKickoff).
 				Build()
 		     ).
 			Build()

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -9,7 +9,7 @@ type ActionBuilder struct {
 	action slackscot.ActionDefinition
 }
 
-func New() (ab *ActionBuilder) {
+func newAction() (ab *ActionBuilder) {
 	ab = new(ActionBuilder)
 	ab.action = slackscot.ActionDefinition{Hidden: false}
 
@@ -23,6 +23,16 @@ func New() (ab *ActionBuilder) {
 	}
 
 	return ab
+}
+
+// NewCommand returns a new ActionBuilder to build a new command
+func NewCommand() (ab *ActionBuilder) {
+	return newAction()
+}
+
+// NewHearAction returns a new ActionBuilder to build a new hear action
+func NewHearAction() (ab *ActionBuilder) {
+	return newAction()
 }
 
 func (ab *ActionBuilder) WithMatcher(matcher slackscot.Matcher) *ActionBuilder {

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -1,26 +1,89 @@
+/*
+Package actions provides a fluent API for creating slackscot plugin actions. Typical usages
+will also involve using the plugin fluent API from github.com/alexandre-normand/slackscot/plugin.
+
+Plugin examples using this API can be found in github.com/alexandre-normand/slackscot/plugins but
+a quick one could look like:
+
+	import (
+		"github.com/alexandre-normand/slackscot"
+		"github.com/alexandre-normand/slackscot/plugin"
+		"github.com/alexandre-normand/slackscot/actions"
+	)
+
+	func newPlugin() (p *slackscot.Plugin) {
+		p = plugin.New("maker").
+		    WithCommand(actions.NewCommand().
+				WithMatcher(func(m *slackscot.IncomingMessage) bool {
+					return strings.HasPrefix(m.NormalizedText, "make")
+				}).
+				WithUsage("make <something>").
+				WithDescription("Make the `<something>` you need").
+				WithAnswerer(func(m *slackscot.IncomingMessage) *slackscot.Answer {
+					return &slackscot.Answer{Text: fmt.Sprintf(":white_check_mark: It's ready for you!")}
+				}).
+				Build()).
+			WithHearAction(actions.NewHearAction().
+				Hidden().
+				WithMatcher(func(m *slackscot.IncomingMessage) bool {
+					return strings.HasPrefix(m.NormalizedText, "chirp")
+				}).
+				WithAnswerer(func(m *slackscot.IncomingMessage) *slackscot.Answer {
+					return &slackscot.Answer{Text: "Did I hear a bird?"}
+				}).
+				Build()
+		     ).
+			WithScheduledAction(actions.NewScheduledAction().
+				...
+				Build()
+		     ).
+			Build()
+		return p
+	}
+*/
 package actions
 
 import (
 	"fmt"
 	"github.com/alexandre-normand/slackscot"
+	"github.com/alexandre-normand/slackscot/schedule"
 )
 
+// ActionBuilder holds the action to build
 type ActionBuilder struct {
 	action slackscot.ActionDefinition
 }
 
-func newAction() (ab *ActionBuilder) {
-	ab = new(ActionBuilder)
-	ab.action = slackscot.ActionDefinition{Hidden: false}
+// ScheduledActionBuilder holds the scheduled action to build
+type ScheduledActionBuilder struct {
+	scheduledAction slackscot.ScheduledActionDefinition
+}
 
+var (
 	// Default to always match. This is acceptable since we can accomplish the same
 	// behavior most of the time by returning nil in the Answerer instead. For most cases,
 	// this is fine as checking for a match still requires the Answerer to extract info
 	// from the same matching logic. A simple matcher can be useful when the matching/triggering
 	// logic can be made entirely separate from the answer logic (i.e. probability matching)
-	ab.action.Match = func(m *slackscot.IncomingMessage) bool {
+	defaultMatcher = func(m *slackscot.IncomingMessage) bool {
 		return true
 	}
+
+	// Default to always return nil. This is not a default you want to use in most cases
+	defaultAnswerer = func(m *slackscot.IncomingMessage) *slackscot.Answer {
+		return nil
+	}
+)
+
+// newAction creates a new action and returns the ActionBuilder to set various attributes
+// of the action. When done with the setup, the caller is expected to call Build() to get
+// the action
+func newAction() (ab *ActionBuilder) {
+	ab = new(ActionBuilder)
+	ab.action = slackscot.ActionDefinition{Hidden: false}
+
+	ab.action.Match = defaultMatcher
+	ab.action.Answer = defaultAnswerer
 
 	return ab
 }
@@ -35,36 +98,81 @@ func NewHearAction() (ab *ActionBuilder) {
 	return newAction()
 }
 
+// WithMatcher sets the action's matcher function
 func (ab *ActionBuilder) WithMatcher(matcher slackscot.Matcher) *ActionBuilder {
 	ab.action.Match = matcher
 	return ab
 }
 
+// WithUsage sets the action usage
 func (ab *ActionBuilder) WithUsage(usage string) *ActionBuilder {
 	ab.action.Usage = usage
 	return ab
 }
 
+// WithDescription sets the action description
 func (ab *ActionBuilder) WithDescription(description string) *ActionBuilder {
 	ab.action.Description = description
 	return ab
 }
 
+// WithDescriptionf sets the action description delegating format and arguments to fmt.Sprintf
 func (ab *ActionBuilder) WithDescriptionf(format string, a ...interface{}) *ActionBuilder {
 	ab.action.Description = fmt.Sprintf(format, a...)
 	return ab
 }
 
+// WithAnswerer sets the action's answerer function
 func (ab *ActionBuilder) WithAnswerer(answerer slackscot.Answerer) *ActionBuilder {
 	ab.action.Answer = answerer
 	return ab
 }
 
+// Hidden sets the action to hidden
 func (ab *ActionBuilder) Hidden() *ActionBuilder {
 	ab.action.Hidden = true
 	return ab
 }
 
+// Build returns the ActionDefinition
 func (ab *ActionBuilder) Build() slackscot.ActionDefinition {
 	return ab.action
+}
+
+// NewScheduledAction returns a new ScheduledActionBuilder to build a new ScheduledActionDefinition
+func NewScheduledAction() (sab *ScheduledActionBuilder) {
+	sab = new(ScheduledActionBuilder)
+	sab.scheduledAction = slackscot.ScheduledActionDefinition{Hidden: false}
+	sab.scheduledAction.Action = func() {}
+
+	return sab
+}
+
+// WithSchedule sets the schedule for the scheduled action
+func (sab *ScheduledActionBuilder) WithSchedule(schedule schedule.Definition) *ScheduledActionBuilder {
+	sab.scheduledAction.Schedule = schedule
+	return sab
+}
+
+// WithDescription sets the scheduled action description
+func (sab *ScheduledActionBuilder) WithDescription(desc string) *ScheduledActionBuilder {
+	sab.scheduledAction.Description = desc
+	return sab
+}
+
+// WithDescriptionf sets the scheduled action description delegating format and arguments to fmt.Sprintf
+func (sab *ScheduledActionBuilder) WithDescriptionf(format string, a ...interface{}) *ScheduledActionBuilder {
+	sab.scheduledAction.Description = fmt.Sprintf(format, a...)
+	return sab
+}
+
+// WithAction sets the action function to run on schedule
+func (sab *ScheduledActionBuilder) WithAction(action slackscot.ScheduledAction) *ScheduledActionBuilder {
+	sab.scheduledAction.Action = action
+	return sab
+}
+
+// Build returns the ScheduledActionDefinition
+func (sab *ScheduledActionBuilder) Build() slackscot.ScheduledActionDefinition {
+	return sab.scheduledAction
 }

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -1,0 +1,54 @@
+package actions
+
+import (
+	"github.com/alexandre-normand/slackscot"
+)
+
+type ActionBuilder struct {
+	action slackscot.ActionDefinition
+}
+
+func New() (ab *ActionBuilder) {
+	ab = new(ActionBuilder)
+	ab.action = slackscot.ActionDefinition{Hidden: false}
+
+	// Default to always match. This is acceptable since we can accomplish the same
+	// behavior most of the time by returning nil in the Answerer instead. For most cases,
+	// this is fine as checking for a match still requires the Answerer to extract info
+	// from the same matching logic. A simple matcher can be useful when the matching/triggering
+	// logic can be made entirely separate from the answer logic (i.e. probability matching)
+	ab.action.Match = func(m *slackscot.IncomingMessage) bool {
+		return true
+	}
+
+	return ab
+}
+
+func (ab *ActionBuilder) WithMatcher(matcher slackscot.Matcher) *ActionBuilder {
+	ab.action.Match = matcher
+	return ab
+}
+
+func (ab *ActionBuilder) WithUsage(usage string) *ActionBuilder {
+	ab.action.Usage = usage
+	return ab
+}
+
+func (ab *ActionBuilder) WithDescription(description string) *ActionBuilder {
+	ab.action.Description = description
+	return ab
+}
+
+func (ab *ActionBuilder) WithAnswerer(answerer slackscot.Answerer) *ActionBuilder {
+	ab.action.Answer = answerer
+	return ab
+}
+
+func (ab *ActionBuilder) Hidden() *ActionBuilder {
+	ab.action.Hidden = true
+	return ab
+}
+
+func (ab *ActionBuilder) Build() slackscot.ActionDefinition {
+	return ab.action
+}

--- a/actions/actions.go
+++ b/actions/actions.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"fmt"
 	"github.com/alexandre-normand/slackscot"
 )
 
@@ -36,6 +37,11 @@ func (ab *ActionBuilder) WithUsage(usage string) *ActionBuilder {
 
 func (ab *ActionBuilder) WithDescription(description string) *ActionBuilder {
 	ab.action.Description = description
+	return ab
+}
+
+func (ab *ActionBuilder) WithDescriptionf(format string, a ...interface{}) *ActionBuilder {
+	ab.action.Description = fmt.Sprintf(format, a...)
 	return ab
 }
 

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -1,0 +1,115 @@
+package actions_test
+
+import (
+	"github.com/alexandre-normand/slackscot"
+	"github.com/alexandre-normand/slackscot/actions"
+	"github.com/alexandre-normand/slackscot/schedule"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewCommandWithDefaults(t *testing.T) {
+	action := actions.NewCommand().Build()
+	assert.False(t, action.Hidden)
+	assert.True(t, action.Match(&slackscot.IncomingMessage{}))
+	assert.Nil(t, action.Answer(&slackscot.IncomingMessage{}))
+}
+
+func TestNewHearActionWithDefaults(t *testing.T) {
+	action := actions.NewHearAction().Build()
+	assert.False(t, action.Hidden)
+	assert.True(t, action.Match(&slackscot.IncomingMessage{}))
+	assert.Nil(t, action.Answer(&slackscot.IncomingMessage{}))
+}
+
+func TestNewActionWithMatcher(t *testing.T) {
+	action := actions.NewHearAction().
+		WithMatcher(func(m *slackscot.IncomingMessage) bool {
+			return false
+		}).
+		Build()
+
+	assert.False(t, action.Match(&slackscot.IncomingMessage{}))
+}
+
+func TestNewActionWithAnswerer(t *testing.T) {
+	action := actions.NewHearAction().
+		WithAnswerer(func(m *slackscot.IncomingMessage) *slackscot.Answer {
+			return &slackscot.Answer{Text: "fake answer"}
+		}).
+		Build()
+
+	assert.Equal(t, &slackscot.Answer{Text: "fake answer"}, action.Answer(&slackscot.IncomingMessage{}))
+}
+
+func TestNewActionWithUsage(t *testing.T) {
+	action := actions.NewHearAction().
+		WithUsage("make something").
+		Build()
+
+	assert.Equal(t, "make something", action.Usage)
+}
+
+func TestNewActionWithDescription(t *testing.T) {
+	action := actions.NewHearAction().
+		WithDescription("Instruct me to make something").
+		Build()
+
+	assert.Equal(t, "Instruct me to make something", action.Description)
+}
+
+func TestNewActionWithDescriptionf(t *testing.T) {
+	action := actions.NewHearAction().
+		WithDescriptionf("Instruct me to make one of %s", []string{"coffee", "soup"}).
+		Build()
+
+	assert.Equal(t, "Instruct me to make one of [coffee soup]", action.Description)
+}
+
+func TestNewHiddenAction(t *testing.T) {
+	action := actions.NewHearAction().
+		Hidden().
+		Build()
+
+	assert.True(t, action.Hidden)
+}
+
+func TestNewScheduledActionWithDefaults(t *testing.T) {
+	action := actions.NewScheduledAction().Build()
+
+	assert.False(t, action.Hidden)
+	assert.Equal(t, schedule.Definition{}, action.Schedule)
+	assert.NotPanics(t, assert.PanicTestFunc(action.Action))
+}
+
+func TestNewScheduledActionWithSchedule(t *testing.T) {
+	action := actions.NewScheduledAction().WithSchedule(schedule.New().WithInterval(1, schedule.Hours).Build()).Build()
+
+	assert.Equal(t, schedule.Definition{Interval: 1, Unit: schedule.Hours}, action.Schedule)
+}
+
+func TestNewScheduledActionWithDescription(t *testing.T) {
+	action := actions.NewScheduledAction().
+		WithDescription("Make a surprise").
+		Build()
+
+	assert.Equal(t, "Make a surprise", action.Description)
+}
+
+func TestNewScheduledActionWithDescriptionf(t *testing.T) {
+	action := actions.NewScheduledAction().
+		WithDescriptionf("Make one of %s", []string{"coffee", "soup"}).
+		Build()
+
+	assert.Equal(t, "Make one of [coffee soup]", action.Description)
+}
+
+func TestNewScheduledActionWithAction(t *testing.T) {
+	action := actions.NewScheduledAction().
+		WithAction(func() {
+			panic("just checking that it's me")
+		}).
+		Build()
+
+	assert.PanicsWithValue(t, "just checking that it's me", assert.PanicTestFunc(action.Action))
+}

--- a/builder.go
+++ b/builder.go
@@ -1,6 +1,7 @@
 package slackscot
 
 import (
+	"github.com/alexandre-normand/slackscot/config"
 	"github.com/spf13/viper"
 	"io"
 )
@@ -18,6 +19,12 @@ func NewBot(name string, v *viper.Viper, options ...Option) (sb *Builder) {
 
 	return sb
 }
+
+// PluginInstantiator creates a new instance of a plugin given a PluginConfig
+type PluginInstantiator func(c *config.PluginConfig) (p *Plugin, err error)
+
+// CloserPluginInstantiator creates a new instance of a closer plugin given a PluginConfig
+type CloserPluginInstantiator func(c *config.PluginConfig) (closer io.Closer, p *Plugin, err error)
 
 // WithPlugin adds a plugin to the slackscot instance
 func (sb *Builder) WithPlugin(p *Plugin) *Builder {
@@ -60,6 +67,42 @@ func (sb *Builder) WithPluginCloserErr(closer io.Closer, p *Plugin, err error) *
 	}
 
 	return sb
+}
+
+// WithConfigurablePluginErr adds a plugin to the slackscot instance by first checking and
+// getting its configuration
+func (sb *Builder) WithConfigurablePluginErr(name string, newInstance PluginInstantiator) *Builder {
+	if pc, exists := sb.loadPluginConfig(name); exists {
+		return sb.WithPluginErr(newInstance(pc))
+	}
+
+	return sb
+}
+
+// WithConfigurablePluginCloser adds a closer plugin to the slackscot instance by first checking and
+// getting its configuration
+func (sb *Builder) WithConfigurablePluginCloserErr(name string, newInstance CloserPluginInstantiator) *Builder {
+	if pc, exists := sb.loadPluginConfig(name); exists {
+		return sb.WithPluginCloserErr(newInstance(pc))
+	}
+
+	return sb
+}
+
+// loadPluginConfig gets the plugin configuration and returns it along with its validity. If false,
+// there is no config for the plugin
+func (sb *Builder) loadPluginConfig(name string) (pc *config.PluginConfig, valid bool) {
+	if sb.err != nil {
+		return nil, false
+	}
+
+	pc, err := config.GetPluginConfig(sb.bot.config, name)
+	if err != nil {
+		sb.err = err
+		return nil, false
+	}
+
+	return pc, true
 }
 
 // Build returns the built slackscot instance. If there was an error during

--- a/builder.go
+++ b/builder.go
@@ -5,11 +5,13 @@ import (
 	"io"
 )
 
+// Builder holds a slackscot instance to build
 type Builder struct {
 	bot *Slackscot
 	err error
 }
 
+// NewBot returns a new Builder used to set up a new slackscot
 func NewBot(name string, v *viper.Viper, options ...Option) (sb *Builder) {
 	sb = new(Builder)
 	sb.bot, sb.err = New(name, v, options...)
@@ -17,6 +19,7 @@ func NewBot(name string, v *viper.Viper, options ...Option) (sb *Builder) {
 	return sb
 }
 
+// WithPlugin adds a plugin to the slackscot instance
 func (sb *Builder) WithPlugin(p *Plugin) *Builder {
 	if sb.err != nil {
 		return sb
@@ -25,6 +28,7 @@ func (sb *Builder) WithPlugin(p *Plugin) *Builder {
 	return sb
 }
 
+// WithPlugin adds a plugin that has a creation function returning (Plugin, error) to the slackscot instance
 func (sb *Builder) WithPluginErr(p *Plugin, err error) *Builder {
 	if sb.err == nil && err != nil {
 		sb.err = err
@@ -39,6 +43,7 @@ func (sb *Builder) WithPluginErr(p *Plugin, err error) *Builder {
 	return sb
 }
 
+// WithPlugin adds a plugin that has a creation function returning (io.Closer, Plugin, error) to the slackscot instance
 func (sb *Builder) WithPluginCloserErr(closer io.Closer, p *Plugin, err error) *Builder {
 	if sb.err == nil && err != nil {
 		sb.err = err
@@ -57,6 +62,12 @@ func (sb *Builder) WithPluginCloserErr(closer io.Closer, p *Plugin, err error) *
 	return sb
 }
 
-func (sb *Builder) Build() Slackscot {
-	return *sb.bot
+// Build returns the built slackscot instance. If there was an error during
+// setup, the error is returned along with a nil slackscot
+func (sb *Builder) Build() (s *Slackscot, err error) {
+	if sb.err != nil {
+		return nil, sb.err
+	}
+
+	return sb.bot, sb.err
 }

--- a/builder.go
+++ b/builder.go
@@ -1,0 +1,62 @@
+package slackscot
+
+import (
+	"github.com/spf13/viper"
+	"io"
+)
+
+type Builder struct {
+	bot *Slackscot
+	err error
+}
+
+func NewBot(name string, v *viper.Viper, options ...Option) (sb *Builder) {
+	sb = new(Builder)
+	sb.bot, sb.err = New(name, v, options...)
+
+	return sb
+}
+
+func (sb *Builder) WithPlugin(p *Plugin) *Builder {
+	if sb.err != nil {
+		return sb
+	}
+
+	return sb
+}
+
+func (sb *Builder) WithPluginErr(p *Plugin, err error) *Builder {
+	if sb.err == nil && err != nil {
+		sb.err = err
+	}
+
+	if sb.err != nil {
+		return sb
+	}
+
+	sb.bot.RegisterPlugin(p)
+
+	return sb
+}
+
+func (sb *Builder) WithPluginCloserErr(closer io.Closer, p *Plugin, err error) *Builder {
+	if sb.err == nil && err != nil {
+		sb.err = err
+	}
+
+	if sb.err != nil {
+		return sb
+	}
+
+	sb.bot.RegisterPlugin(p)
+
+	if closer != nil {
+		sb.bot.closers = append(sb.bot.closers, closer)
+	}
+
+	return sb
+}
+
+func (sb *Builder) Build() Slackscot {
+	return *sb.bot
+}

--- a/builder_test.go
+++ b/builder_test.go
@@ -1,0 +1,144 @@
+package slackscot_test
+
+import (
+	"fmt"
+	"github.com/alexandre-normand/slackscot"
+	"github.com/alexandre-normand/slackscot/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestNewSlackscotWithoutPlugins(t *testing.T) {
+	b, err := slackscot.NewBot("jane", config.NewViperWithDefaults()).
+		Build()
+
+	require.NoError(t, err)
+	require.NotNil(t, b)
+}
+
+func TestNewSlackscotWithSimplePlugin(t *testing.T) {
+	b, err := slackscot.NewBot("jane", config.NewViperWithDefaults()).
+		WithPlugin(newPlugin()).
+		Build()
+
+	require.NoError(t, err)
+	require.NotNil(t, b)
+}
+
+func TestNewSlackscotWithPluginAndError(t *testing.T) {
+	b, err := slackscot.NewBot("jane", config.NewViperWithDefaults()).
+		WithPluginErr(newPluginWithErr("")).
+		Build()
+
+	require.NoError(t, err)
+	require.NotNil(t, b)
+}
+
+func TestNewSlackscotWithPluginAndErrorSet(t *testing.T) {
+	b, err := slackscot.NewBot("jane", config.NewViperWithDefaults()).
+		WithPluginErr(newPluginWithErr("error1")).
+		Build()
+
+	require.Error(t, err)
+	assert.EqualError(t, err, "error1")
+	assert.Nil(t, b)
+}
+
+func TestNewSlackscotWithPluginAndManyErrors(t *testing.T) {
+	b, err := slackscot.NewBot("jane", config.NewViperWithDefaults()).
+		WithPluginErr(newPluginWithErr("error1")).
+		WithPluginErr(newPluginWithErr("error2")).
+		WithPlugin(newPlugin()).
+		Build()
+
+	require.Error(t, err)
+	assert.EqualError(t, err, "error1")
+	assert.Nil(t, b)
+}
+
+func TestNewSlackscotWithCloserPluginClosingWithError(t *testing.T) {
+	b, err := slackscot.NewBot("jane", config.NewViperWithDefaults()).
+		WithPluginCloserErr(newPluginWithErrAndCloser("", CloseTester{errorMsg: "should be called"})).
+		Build()
+
+	require.NoError(t, err)
+	require.NotNil(t, b)
+
+	err = b.Close()
+	assert.EqualError(t, err, "should be called")
+}
+
+func TestNewSlackscotWithCloserPluginClosingWithoutError(t *testing.T) {
+	b, err := slackscot.NewBot("jane", config.NewViperWithDefaults()).
+		WithPluginCloserErr(newPluginWithErrAndCloser("", CloseTester{errorMsg: ""})).
+		Build()
+
+	require.NoError(t, err)
+	require.NotNil(t, b)
+
+	err = b.Close()
+	assert.NoError(t, err)
+}
+
+func TestNewSlackscotWithCloserAndErr(t *testing.T) {
+	b, err := slackscot.NewBot("jane", config.NewViperWithDefaults()).
+		WithPluginCloserErr(newPluginWithErrAndCloser("error1", CloseTester{})).
+		WithPluginCloserErr(newPluginWithErrAndCloser("error2", CloseTester{})).
+		Build()
+
+	require.Error(t, err)
+	assert.EqualError(t, err, "error1")
+	assert.Nil(t, b)
+}
+
+// newPlugin returns a new tester plugin
+func newPlugin() (p *slackscot.Plugin) {
+	p = new(slackscot.Plugin)
+	p.Name = "tester"
+	p.Commands = []slackscot.ActionDefinition{{
+		Match: func(m *slackscot.IncomingMessage) bool {
+			return strings.HasPrefix(m.NormalizedText, "make")
+		},
+		Usage:       "make `<something>`",
+		Description: "Have the test bot make something for you",
+		Answer: func(m *slackscot.IncomingMessage) *slackscot.Answer {
+			return &slackscot.Answer{Text: "Ready"}
+		},
+	}}
+
+	return p
+}
+
+// newPluginWithErr returns the plugin along with an error if errorMsg is not empty
+func newPluginWithErr(errorMsg string) (p *slackscot.Plugin, err error) {
+	if errorMsg != "" {
+		return nil, fmt.Errorf(errorMsg)
+	}
+
+	return newPlugin(), nil
+}
+
+// newPluginWithErr returns the plugin along with an error if errorMsg is not empty and the closer
+func newPluginWithErrAndCloser(errorMsg string, closer io.Closer) (c io.Closer, p *slackscot.Plugin, err error) {
+	p, err = newPluginWithErr(errorMsg)
+
+	return closer, p, err
+}
+
+// CloseTester is an empty struct that has is a Closer that either doesn't do anything
+// or returns the error set on the CloseTester
+type CloseTester struct {
+	errorMsg string
+}
+
+// Close returns the CloseTester error if set, or just returns nil and does nothing otherwise
+func (c CloseTester) Close() (err error) {
+	if c.errorMsg != "" {
+		return fmt.Errorf(c.errorMsg)
+	}
+
+	return nil
+}

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,50 @@
+/*
+Package slackscot provides the building blocks to create a slack bot.
+
+It is easily extendable via plugins that can combine commands, hear actions (listeners) as well
+as scheduled actions. It also supports updating of triggered responses on message updates as well
+as deleting triggered responses when the triggering messages are deleted by users.
+
+Plugins also have access to services injected on startup by slackscot such as:
+ - UserInfoFinder: To query user info
+ - SLogger: To log debug/info statements
+ - EmojiReactor: To emoji react to messages
+ - FileUploader: To upload files
+ - RealTimeMessageSender: To send unmanaged real time messages outside the normal reaction flow (i.e. for sending many messages or sending via a scheduled action)
+
+Example code (from https://github.com/alexandre-normand/youppi):
+
+	package main
+
+	import (
+		"github.com/alexandre-normand/slackscot"
+		"github.com/alexandre-normand/slackscot/config"
+		"github.com/alexandre-normand/slackscot/plugins"
+ 		"gopkg.in/alecthomas/kingpin.v2"
+ 		"io"
+	)
+
+	func main() {
+		// TODO: Parse command-line, initialize viper and instantiate Storer implementation for needed for some plugins
+
+		youppi, err := slackscot.NewBot("youppi", v, options...).
+			WithPlugin(plugins.NewKarma(karmaStorer)).
+			WithPlugin(plugins.NewTriggerer(triggererStorer)).
+			WithConfigurablePluginErr(plugins.FingerQuoterPluginName, func(conf *config.PluginConfig) (p *slackscot.Plugin, err) { plugins.NewFingerQuoter(c) }).
+			WithConfigurablePluginCloserErr(plugins.EmojiBannerPluginName, func(conf *config.PluginConfig) (c io.Closer, p *slackscot.Plugin, err) { plugins.NewEmojiBannerMaker(c) }).
+			WithConfigurablePluginErr(plugins.OhMondayPluginName, func(conf *config.PluginConfig) (p *slackscot.Plugin, err) { plugins.NewOhMonday(c) }).
+			WithPlugin(plugins.NewVersionner(name, version)).
+			Build()
+		defer youppi.Close()
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		err = youppi.Run()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+*/
+package slackscot

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,10 +1,50 @@
+/*
+Package plugin provides a fluent API for creating slackscot plugins. Typical usages
+will also involve using the actions fluent API from github.com/alexandre-normand/slackscot/actions.
+
+Plugin examples using this API can be found in github.com/alexandre-normand/slackscot/plugins but
+a quick one could look like:
+
+	import (
+		"github.com/alexandre-normand/slackscot"
+		"github.com/alexandre-normand/slackscot/plugin"
+		"github.com/alexandre-normand/slackscot/actions"
+	)
+
+	func newPlugin() (p *slackscot.Plugin) {
+		p = plugin.New("maker").
+		    WithCommand(actions.NewCommand().
+				WithMatcher(func(m *slackscot.IncomingMessage) bool {
+					return strings.HasPrefix(m.NormalizedText, "make")
+				}).
+				WithUsage("make <something>").
+				WithDescription("Make the `<something>` you need").
+				WithAnswerer(func(m *slackscot.IncomingMessage) *slackscot.Answer {
+					return &slackscot.Answer{Text: fmt.Sprintf(":white_check_mark: It's ready for you!")}
+				}).
+				Build()).
+			WithHearAction(actions.NewHearAction().
+				Hidden().
+				WithMatcher(func(m *slackscot.IncomingMessage) bool {
+					return strings.HasPrefix(m.NormalizedText, "chirp")
+				}).
+				WithAnswerer(func(m *slackscot.IncomingMessage) *slackscot.Answer {
+					return &slackscot.Answer{Text: "Did I hear a bird?"}
+				}).
+				Build()
+		     ).
+			Build()
+		return p
+	}
+*/
 package plugin
 
 import (
 	"github.com/alexandre-normand/slackscot"
 )
 
-// PluginBuilder holds a plugin to build
+// PluginBuilder holds a plugin to build. This is used to set up
+// a plugin that can be returned using Build
 type PluginBuilder struct {
 	plugin *slackscot.Plugin
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,0 +1,45 @@
+package plugin
+
+import (
+	"github.com/alexandre-normand/slackscot"
+)
+
+// PluginBuilder holds a plugin to build
+type PluginBuilder struct {
+	plugin *slackscot.Plugin
+}
+
+// New creates a new PluginBuilder with a plugin with the given name and empty set of actions
+func New(name string) (pb *PluginBuilder) {
+	pb = new(PluginBuilder)
+	pb.plugin = new(slackscot.Plugin)
+	pb.plugin.Name = name
+	pb.plugin.Commands = make([]slackscot.ActionDefinition, 0)
+	pb.plugin.HearActions = make([]slackscot.ActionDefinition, 0)
+	pb.plugin.ScheduledActions = make([]slackscot.ScheduledActionDefinition, 0)
+
+	return pb
+}
+
+// WithCommand adds a command to the plugin
+func (pb *PluginBuilder) WithCommand(command slackscot.ActionDefinition) *PluginBuilder {
+	pb.plugin.Commands = append(pb.plugin.Commands, command)
+	return pb
+}
+
+// WithHearAction adds an hear action to the plugin
+func (pb *PluginBuilder) WithHearAction(hearAction slackscot.ActionDefinition) *PluginBuilder {
+	pb.plugin.HearActions = append(pb.plugin.HearActions, hearAction)
+	return pb
+}
+
+// WithScheduledAction adds a scheduled action to the plugin
+func (pb *PluginBuilder) ScheduledAction(scheduledAction slackscot.ScheduledActionDefinition) *PluginBuilder {
+	pb.plugin.ScheduledActions = append(pb.plugin.ScheduledActions, scheduledAction)
+	return pb
+}
+
+// Build returns the created Plugin instance
+func (pb *PluginBuilder) Build() (p *slackscot.Plugin) {
+	return pb.plugin
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -22,7 +22,8 @@ a quick one could look like:
 				WithAnswerer(func(m *slackscot.IncomingMessage) *slackscot.Answer {
 					return &slackscot.Answer{Text: fmt.Sprintf(":white_check_mark: It's ready for you!")}
 				}).
-				Build()).
+				Build()
+			 ).
 			WithHearAction(actions.NewHearAction().
 				Hidden().
 				WithMatcher(func(m *slackscot.IncomingMessage) bool {
@@ -31,6 +32,12 @@ a quick one could look like:
 				WithAnswerer(func(m *slackscot.IncomingMessage) *slackscot.Answer {
 					return &slackscot.Answer{Text: "Did I hear a bird?"}
 				}).
+				Build()
+		     ).
+		    WithScheduledAction(actions.NewScheduledAction().
+				WithSchedule(schedule.New().Every(time.Monday.string()).AtTime("10:00").Build()).
+				WithDescription("Start the week off").
+				WithAction(weeklyKickoff).
 				Build()
 		     ).
 			Build()

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -33,6 +33,12 @@ func (pb *PluginBuilder) WithHearAction(hearAction slackscot.ActionDefinition) *
 	return pb
 }
 
+// WithCommandNamespacing enables command namespacing for that plugin
+func (pb *PluginBuilder) WithCommandNamespacing() *PluginBuilder {
+	pb.plugin.NamespaceCommands = true
+	return pb
+}
+
 // WithScheduledAction adds a scheduled action to the plugin
 func (pb *PluginBuilder) ScheduledAction(scheduledAction slackscot.ScheduledActionDefinition) *PluginBuilder {
 	pb.plugin.ScheduledActions = append(pb.plugin.ScheduledActions, scheduledAction)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -40,7 +40,7 @@ func (pb *PluginBuilder) WithCommandNamespacing() *PluginBuilder {
 }
 
 // WithScheduledAction adds a scheduled action to the plugin
-func (pb *PluginBuilder) ScheduledAction(scheduledAction slackscot.ScheduledActionDefinition) *PluginBuilder {
+func (pb *PluginBuilder) WithScheduledAction(scheduledAction slackscot.ScheduledActionDefinition) *PluginBuilder {
 	pb.plugin.ScheduledActions = append(pb.plugin.ScheduledActions, scheduledAction)
 	return pb
 }

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -1,0 +1,78 @@
+package plugin_test
+
+import (
+	"github.com/alexandre-normand/slackscot/actions"
+	"github.com/alexandre-normand/slackscot/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestDefaultNewPlugin(t *testing.T) {
+	p := plugin.New("loopy").Build()
+
+	require.NotNil(t, p)
+	assert.Equal(t, "loopy", p.Name)
+	assert.False(t, p.NamespaceCommands)
+	assert.Empty(t, p.Commands)
+	assert.Empty(t, p.HearActions)
+	assert.Empty(t, p.ScheduledActions)
+}
+
+func TestPluginWithSingleCommand(t *testing.T) {
+	p := plugin.New("loopy").
+		WithCommand(actions.NewCommand().Build()).
+		Build()
+
+	require.NotNil(t, p)
+	assert.Len(t, p.Commands, 1)
+	assert.Empty(t, p.HearActions)
+	assert.Empty(t, p.ScheduledActions)
+}
+
+func TestPluginWithManyCommands(t *testing.T) {
+	p := plugin.New("loopy").
+		WithCommand(actions.NewCommand().WithUsage("command1").Build()).
+		WithCommand(actions.NewCommand().WithUsage("command2").Build()).
+		Build()
+
+	require.NotNil(t, p)
+	require.Len(t, p.Commands, 2)
+	assert.Equal(t, "command1", p.Commands[0].Usage)
+	assert.Equal(t, "command2", p.Commands[1].Usage)
+	assert.Empty(t, p.HearActions)
+	assert.Empty(t, p.ScheduledActions)
+}
+
+func TestPluginWithCommandsAndHearActions(t *testing.T) {
+	p := plugin.New("loopy").
+		WithCommand(actions.NewCommand().WithUsage("command").Build()).
+		WithHearAction(actions.NewCommand().WithUsage("listener").Build()).
+		Build()
+
+	require.NotNil(t, p)
+	require.Len(t, p.Commands, 1)
+	assert.Equal(t, "command", p.Commands[0].Usage)
+	require.Len(t, p.HearActions, 1)
+	assert.Equal(t, "listener", p.HearActions[0].Usage)
+	assert.Empty(t, p.ScheduledActions)
+}
+
+func TestPluginWithScheduledActions(t *testing.T) {
+	p := plugin.New("loopy").
+		WithScheduledAction(actions.NewScheduledAction().WithDescription("Check service status").Build()).
+		Build()
+
+	require.NotNil(t, p)
+	require.Len(t, p.ScheduledActions, 1)
+	assert.Equal(t, "Check service status", p.ScheduledActions[0].Description)
+}
+
+func TestPluginWithCommandNamespacing(t *testing.T) {
+	p := plugin.New("loopy").
+		WithCommandNamespacing().
+		Build()
+
+	require.NotNil(t, p)
+	assert.True(t, p.NamespaceCommands)
+}

--- a/plugins/emojibanner.go
+++ b/plugins/emojibanner.go
@@ -71,9 +71,7 @@ func NewEmojiBannerMaker(c *config.PluginConfig) (toClose io.Closer, emojiBanner
 	ebm := new(EmojiBannerMaker)
 	ebm.Plugin = plugin.New(EmojiBannerPluginName).
 		WithCommand(actions.NewCommand().
-			WithMatcher(func(m *slackscot.IncomingMessage) bool {
-				return strings.HasPrefix(m.NormalizedText, "emoji banner")
-			}).
+			WithMatcher(matchBannerCommand).
 			WithUsage("emoji banner <word of 5 characters or less> <emoji>").
 			WithDescription("Renders a single-word banner with the provided emoji").
 			WithAnswerer(func(m *slackscot.IncomingMessage) *slackscot.Answer {
@@ -84,6 +82,11 @@ func NewEmojiBannerMaker(c *config.PluginConfig) (toClose io.Closer, emojiBanner
 	ebm.tempDirFontPath = tempDirFontPath
 
 	return ebm, ebm.Plugin, nil
+}
+
+// matchBannerCommand returns true if the incoming message starts with emoji banner
+func matchBannerCommand(m *slackscot.IncomingMessage) bool {
+	return strings.HasPrefix(m.NormalizedText, "emoji banner")
 }
 
 // Close cleans up resources (temp font directory) used by the plugin

--- a/plugins/emojibanner.go
+++ b/plugins/emojibanner.go
@@ -70,7 +70,7 @@ func NewEmojiBannerMaker(c *config.PluginConfig) (toClose io.Closer, emojiBanner
 
 	ebm := new(EmojiBannerMaker)
 	ebm.Plugin = plugin.New(EmojiBannerPluginName).
-		WithCommand(actions.New().
+		WithCommand(actions.NewCommand().
 			WithMatcher(func(m *slackscot.IncomingMessage) bool {
 				return strings.HasPrefix(m.NormalizedText, "emoji banner")
 			}).

--- a/plugins/emojibanner_test.go
+++ b/plugins/emojibanner_test.go
@@ -14,21 +14,21 @@ import (
 func TestEmojiBannerTrigger(t *testing.T) {
 	pc := viper.New()
 
-	ebm, err := plugins.NewEmojiBannerMaker(pc)
+	ebm, p, err := plugins.NewEmojiBannerMaker(pc)
 	assert.NoError(t, err)
 	defer ebm.Close()
 
 	assertplugin := assertplugin.New(t, "robert")
 
-	assertplugin.AnswersAndReacts(&ebm.Plugin, &slack.Msg{Text: "<@robert> other"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "<@robert> other"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers)
 	})
 
-	assertplugin.AnswersAndReacts(&ebm.Plugin, &slack.Msg{Text: "<@robert> emoji"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "<@robert> emoji"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers)
 	})
 
-	assertplugin.AnswersAndReacts(&ebm.Plugin, &slack.Msg{Text: "<@robert> emoji banner cat :cat:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "<@robert> emoji banner cat :cat:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\r\n⬜️⬜️:cat::cat::cat::cat::cat::cat:⬜️⬜️⬜️⬜️⬜️⬜️:cat::cat::cat:⬜️⬜️⬜️⬜️⬜️⬜️:cat::cat::cat:"+
 			":cat::cat::cat::cat::cat::cat::cat::cat::cat::cat:\n⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️:cat:\n:cat:⬜️⬜️:cat:"+
 			":cat::cat::cat::cat::cat:⬜️⬜️⬜️:cat:⬜️⬜️:cat:⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat::cat::cat::cat::cat:⬜️⬜️:cat::cat::cat::cat::cat::cat:\n:cat:⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️⬜️:cat:⬜️⬜️"+
@@ -41,17 +41,17 @@ func TestEmojiBannerTrigger(t *testing.T) {
 func TestEmojiBannerGenerationWithWrongUsage(t *testing.T) {
 	pc := viper.New()
 
-	ebm, err := plugins.NewEmojiBannerMaker(pc)
+	ebm, p, err := plugins.NewEmojiBannerMaker(pc)
 	assert.NoError(t, err)
 	defer ebm.Close()
 
 	assertplugin := assertplugin.New(t, "robert")
 
-	assertplugin.AnswersAndReacts(&ebm.Plugin, &slack.Msg{Text: "<@robert> emoji banner"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "<@robert> emoji banner"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "`Wrong usage`: emoji banner `<word of 4 characters or less>` `<emoji>`")
 	})
 
-	assertplugin.AnswersAndReacts(&ebm.Plugin, &slack.Msg{Text: "<@robert> emoji banner cats"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "<@robert> emoji banner cats"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "`Wrong usage`: emoji banner `<word of 4 characters or less>` `<emoji>`")
 	})
 }
@@ -59,13 +59,13 @@ func TestEmojiBannerGenerationWithWrongUsage(t *testing.T) {
 func TestEmojiBannerGenerationWithLongWord(t *testing.T) {
 	pc := viper.New()
 
-	ebm, err := plugins.NewEmojiBannerMaker(pc)
+	ebm, p, err := plugins.NewEmojiBannerMaker(pc)
 	assert.NoError(t, err)
 	defer ebm.Close()
 
 	assertplugin := assertplugin.New(t, "robert")
 
-	assertplugin.AnswersAndReacts(&ebm.Plugin, &slack.Msg{Text: "<@robert> emoji banner hello :bug:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "<@robert> emoji banner hello :bug:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "`Wrong usage` (word *longer* than `4` characters): emoji banner `<word of 5 characters or less>` `<emoji>`")
 	})
 }
@@ -73,13 +73,13 @@ func TestEmojiBannerGenerationWithLongWord(t *testing.T) {
 func TestEmojiBannerGenerationWithDefaultFont(t *testing.T) {
 	pc := viper.New()
 
-	ebm, err := plugins.NewEmojiBannerMaker(pc)
+	ebm, p, err := plugins.NewEmojiBannerMaker(pc)
 	assert.NoError(t, err)
 	defer ebm.Close()
 
 	assertplugin := assertplugin.New(t, "robert")
 
-	assertplugin.AnswersAndReacts(&ebm.Plugin, &slack.Msg{Text: "<@robert> emoji banner cat :cat:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "<@robert> emoji banner cat :cat:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\r\n⬜️⬜️:cat::cat::cat::cat::cat::cat:⬜️⬜️⬜️⬜️⬜️⬜️:cat::cat::cat:⬜️⬜️⬜️⬜️⬜️⬜️:cat::cat::cat:"+
 			":cat::cat::cat::cat::cat::cat::cat::cat::cat::cat:\n⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️:cat:\n:cat:⬜️⬜️:cat:"+
 			":cat::cat::cat::cat::cat:⬜️⬜️⬜️:cat:⬜️⬜️:cat:⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat::cat::cat::cat::cat:⬜️⬜️:cat::cat::cat::cat::cat::cat:\n:cat:⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️⬜️:cat:⬜️⬜️"+
@@ -93,13 +93,13 @@ func TestEmojiBannerGenerationWithBannerFont(t *testing.T) {
 	pc := viper.New()
 	pc.Set("figletFontUrl", "http://www.figlet.org/fonts/banner.flf")
 
-	ebm, err := plugins.NewEmojiBannerMaker(pc)
+	ebm, p, err := plugins.NewEmojiBannerMaker(pc)
 	assert.NoError(t, err)
 	defer ebm.Close()
 
 	assertplugin := assertplugin.New(t, "robert")
 
-	assertplugin.AnswersAndReacts(&ebm.Plugin, &slack.Msg{Text: "<@robert> emoji banner cat :cat:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "<@robert> emoji banner cat :cat:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\r\n⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️⬜️\n⬜️⬜️:cat::cat::cat::cat:⬜️⬜️⬜️⬜️⬜️:cat:"+
 			":cat:⬜️⬜️⬜️⬜️:cat::cat::cat::cat::cat:⬜️\n⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️:cat:⬜️⬜️:cat:⬜️⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️\n⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️"+
 			":cat:⬜️⬜️⬜️\n⬜️:cat:⬜️⬜️⬜️⬜️⬜️⬜️⬜️:cat::cat::cat::cat::cat::cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️\n⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️⬜️:cat:⬜️⬜️⬜️\n"+
@@ -111,7 +111,7 @@ func TestBadFontURLShouldFailPluginCreation(t *testing.T) {
 	pc := viper.New()
 	pc.Set("figletFontUrl", "https://invalid.url.is.bad/")
 
-	_, err := plugins.NewEmojiBannerMaker(pc)
+	_, _, err := plugins.NewEmojiBannerMaker(pc)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Error loading font url")
 	}
@@ -121,7 +121,7 @@ func TestInvalidFontURLShouldFailPluginCreation(t *testing.T) {
 	pc := viper.New()
 	pc.Set("figletFontUrl", "%proto:")
 
-	_, err := plugins.NewEmojiBannerMaker(pc)
+	_, _, err := plugins.NewEmojiBannerMaker(pc)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Invalid font url")
 	}

--- a/plugins/fingerquoter.go
+++ b/plugins/fingerquoter.go
@@ -47,7 +47,7 @@ func NewFingerQuoter(config *config.PluginConfig) (p *slackscot.Plugin, err erro
 	f.frequency = config.GetInt(frequencyKey)
 
 	f.Plugin = plugin.New(FingerQuoterPluginName).
-		WithHearAction(actions.New().
+		WithHearAction(actions.NewHearAction().
 			Hidden().
 			WithMatcher(f.trigger).
 			WithUsage("just converse").

--- a/plugins/fingerquoter_test.go
+++ b/plugins/fingerquoter_test.go
@@ -28,7 +28,7 @@ func TestMatchFrequency(t *testing.T) {
 	// With a frequency of 2, every other timestamp should match (no whitelist defined means that all channels are enabled)
 	pc.Set("frequency", 2)
 
-	f, err := plugins.NewFingerQuoter(pc)
+	p, err := plugins.NewFingerQuoter(pc)
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
@@ -38,7 +38,7 @@ func TestMatchFrequency(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		msgt := fmt.Sprintf(ts, i)
 
-		assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Timestamp: msgt}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Timestamp: msgt}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			matches = matches + len(answers)
 			return true
 		})
@@ -53,20 +53,20 @@ func TestChannelWhitelisting(t *testing.T) {
 	pc.Set("frequency", 1)
 	pc.Set("channelIDs", []string{"channel1", "channel2"})
 
-	f, err := plugins.NewFingerQuoter(pc)
+	p, err := plugins.NewFingerQuoter(pc)
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel1", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel1", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"thing\"")
 	})
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel2", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel2", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"thing\"")
 	})
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel3", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel3", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers)
 	})
 }
@@ -78,20 +78,20 @@ func TestChannelIgnoring(t *testing.T) {
 	pc.Set("channelIDs", []string{"channel1", "channel2"})
 	pc.Set("ignoredChannelIDs", []string{"channel2"})
 
-	f, err := plugins.NewFingerQuoter(pc)
+	p, err := plugins.NewFingerQuoter(pc)
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel1", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel1", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"thing\"")
 	})
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel2", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel2", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers)
 	})
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel3", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel3", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers)
 	})
 }
@@ -103,20 +103,20 @@ func TestChannelIgnoredWithDefaultWhitelisting(t *testing.T) {
 	pc.Set("channelIDs", "")
 	pc.Set("ignoredChannelIDs", []string{"channel2"})
 
-	f, err := plugins.NewFingerQuoter(pc)
+	p, err := plugins.NewFingerQuoter(pc)
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel1", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel1", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"thing\"")
 	})
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel2", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel2", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers)
 	})
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel3", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel3", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"thing\"")
 	})
 }
@@ -127,20 +127,20 @@ func TestDefaultWhitelistingEnablesForAll(t *testing.T) {
 	pc.Set("frequency", 1)
 	pc.Set("channelIDs", "")
 
-	f, err := plugins.NewFingerQuoter(pc)
+	p, err := plugins.NewFingerQuoter(pc)
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel1", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel1", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"thing\"")
 	})
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel2", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel2", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"thing\"")
 	})
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel3", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel3", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"thing\"")
 	})
 }
@@ -149,17 +149,17 @@ func TestMatchConsistentWithSameTimestamp(t *testing.T) {
 	pc := viper.New()
 	pc.Set("frequency", 2)
 
-	f, err := plugins.NewFingerQuoter(pc)
+	p, err := plugins.NewFingerQuoter(pc)
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
 
 	for i := 0; i < 100; i++ {
-		assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel1", Timestamp: "1546833210.036903"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel1", Timestamp: "1546833210.036903"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1)
 		})
 
-		assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel1", Timestamp: "1546833222.031904"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel1", Timestamp: "1546833222.031904"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, answers)
 		})
 	}
@@ -169,7 +169,7 @@ func TestMatchFalseWhenCorruptedTimestamp(t *testing.T) {
 	pc := viper.New()
 	pc.Set("frequency", 1)
 
-	f, err := plugins.NewFingerQuoter(pc)
+	p, err := plugins.NewFingerQuoter(pc)
 	assert.Nil(t, err)
 
 	// Set debug logger
@@ -178,7 +178,7 @@ func TestMatchFalseWhenCorruptedTimestamp(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot", assertplugin.OptionLog(logger))
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "some random thing someone could say", Channel: "channel1", Timestamp: "NotAFloatValue"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "some random thing someone could say", Channel: "channel1", Timestamp: "NotAFloatValue"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers) && assert.Contains(t, b.String(), "error converting timestamp to float")
 	})
 }
@@ -187,7 +187,7 @@ func TestNoAnswerWhenCorruptedTimestamp(t *testing.T) {
 	pc := viper.New()
 	pc.Set("frequency", 1)
 
-	f, err := plugins.NewFingerQuoter(pc)
+	p, err := plugins.NewFingerQuoter(pc)
 	assert.Nil(t, err)
 
 	// Attach logger to plugin
@@ -196,7 +196,7 @@ func TestNoAnswerWhenCorruptedTimestamp(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot", assertplugin.OptionLog(logger))
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "This is a text with longer and shorter words", Timestamp: "NotAFloatValue"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "This is a text with longer and shorter words", Timestamp: "NotAFloatValue"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers) && assert.Contains(t, b.String(), "error converting timestamp to float")
 	})
 }
@@ -205,12 +205,12 @@ func TestQuotingOfSingleLongWord(t *testing.T) {
 	pc := viper.New()
 	pc.Set("frequency", 1)
 
-	f, err := plugins.NewFingerQuoter(pc)
+	p, err := plugins.NewFingerQuoter(pc)
 	assert.Nil(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "Do I belong or not?", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "Do I belong or not?", Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"belong\"")
 	})
 }
@@ -219,12 +219,12 @@ func TestNotQuotingPartsOfURLs(t *testing.T) {
 	pc := viper.New()
 	pc.Set("frequency", 1)
 
-	f, err := plugins.NewFingerQuoter(pc)
+	p, err := plugins.NewFingerQuoter(pc)
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "https://google.com/query?bigfoot=friend", Timestamp: "1546833310.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "https://google.com/query?bigfoot=friend", Timestamp: "1546833310.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers)
 	})
 }
@@ -234,13 +234,13 @@ func TestConsistentWordQuotingWithSameTimestamp(t *testing.T) {
 	pc.Set("frequency", 1)
 	pc.Set("channelIDs", "")
 
-	f, err := plugins.NewFingerQuoter(pc)
+	p, err := plugins.NewFingerQuoter(pc)
 	assert.Nil(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
 
 	// Validate one pick with a different timestamp
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
 			Where the lock that you locked in the suite says there's no prying. When the breath that you breathed in 
 			the street screams there's no science`, Timestamp: "1546833315.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"breath\"")
@@ -248,7 +248,7 @@ func TestConsistentWordQuotingWithSameTimestamp(t *testing.T) {
 
 	// Validate that calling the answer function a hundred times with the same timestamp results in the same pick
 	for i := 0; i < 100; i++ {
-		if !assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
+		if !assertplugin.AnswersAndReacts(p, &slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
 			Where the lock that you locked in the suite says there's no prying. When the breath that you breathed in 
 			the street screams there's no science`, Timestamp: "1546833210.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"street\"")
@@ -259,7 +259,7 @@ func TestConsistentWordQuotingWithSameTimestamp(t *testing.T) {
 
 	// Validate that a timestamp *almost* equal to the prior one (except for decimals) results in something different to make sure
 	// we don't ignore those
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: `It's just a bad movie, where there's no crying. Handing the keys to me in this Red Lion. 
 			Where the lock that you locked in the suite says there's no prying. When the breath that you breathed in 
 			the street screams there's no science`, Timestamp: "1546833210.036907"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "\"Where\"")
@@ -270,12 +270,12 @@ func TestNoQuotingIfOnlySmallWords(t *testing.T) {
 	pc := viper.New()
 	pc.Set("frequency", 1)
 
-	f, err := plugins.NewFingerQuoter(pc)
+	p, err := plugins.NewFingerQuoter(pc)
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&f.Plugin, &slack.Msg{Text: "Do I or not?", Timestamp: "1546833310.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "Do I or not?", Timestamp: "1546833310.036900"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers)
 	})
 }

--- a/plugins/karma.go
+++ b/plugins/karma.go
@@ -88,37 +88,37 @@ func NewKarma(storer store.GlobalSiloStringStorer) (karma *slackscot.Plugin) {
 
 	k.Plugin = plugin.New(KarmaPluginName).
 		WithCommandNamespacing().
-		WithCommand(actions.New().
+		WithCommand(actions.NewCommand().
 			WithMatcher(matchKarmaTopReport).
 			WithUsage("top [count]").
 			WithDescriptionf("Return the top things ever recorded in this channel (default of %d items)", defaultItemCount).
 			WithAnswerer(k.answerKarmaTop).
 			Build()).
-		WithCommand(actions.New().
+		WithCommand(actions.NewCommand().
 			WithMatcher(matchKarmaWorstReport).
 			WithUsage("worst [count]").
 			WithDescriptionf("Return the worst things ever recorded in this channel (default of %d items)", defaultItemCount).
 			WithAnswerer(k.answerKarmaWorst).
 			Build()).
-		WithCommand(actions.New().
+		WithCommand(actions.NewCommand().
 			WithMatcher(matchGlobalKarmaTopReport).
 			WithUsage("global top [count]").
 			WithDescriptionf("Return the top things ever over all channels (default of %d items)", defaultItemCount).
 			WithAnswerer(k.answerGlobalKarmaTop).
 			Build()).
-		WithCommand(actions.New().
+		WithCommand(actions.NewCommand().
 			WithMatcher(matchGlobalKarmaWorstReport).
 			WithUsage("global worst [count]").
 			WithDescriptionf("Return the worst things ever over all channels (default of %d items)", defaultItemCount).
 			WithAnswerer(k.answerGlobalKarmaWorst).
 			Build()).
-		WithCommand(actions.New().
+		WithCommand(actions.NewCommand().
 			WithMatcher(matchKarmaReset).
 			WithUsage("reset").
 			WithDescription("Resets all recorded karma for the current channel").
 			WithAnswerer(k.clearChannelKarma).
 			Build()).
-		WithHearAction(actions.New().
+		WithHearAction(actions.NewCommand().
 			WithMatcher(matchKarmaRecord).
 			WithUsage("thing++ or thing--").
 			WithDescription("Keep track of karma").

--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -73,15 +73,15 @@ func TestKarmaMatchesAndAnswers(t *testing.T) {
 	defer storer.Close()
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(storer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(storer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	if assert.NotNil(t, k) {
+	if assert.NotNil(t, p) {
 		for _, tc := range testCases {
 			t.Run(tc.text, func(t *testing.T) {
-				assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: tc.channel, Text: tc.text}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+				assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: tc.channel, Text: tc.text}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 					if len(tc.expectedAnswer) > 0 {
 						return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], tc.expectedAnswer)
 					}
@@ -101,12 +101,12 @@ func TestErrorStoringKarmaRecord(t *testing.T) {
 	mockStorer.On("PutSiloString", "myLittleChannel", "thing", "1").Return(fmt.Errorf("can't persist"))
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "thing++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "thing++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers)
 	})
 }
@@ -119,12 +119,12 @@ func TestInvalidStoredKarmaShouldResetValue(t *testing.T) {
 	mockStorer.On("PutSiloString", "myLittleChannel", "thing", "1").Return(nil)
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "thing++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "thing++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "`thing` just gained a level (`thing`: 1)")
 	})
 }
@@ -136,12 +136,12 @@ func TestErrorGettingList(t *testing.T) {
 	mockStorer.On("ScanSilo", "myLittleChannel").Return(map[string]string{}, fmt.Errorf("can't load karma"))
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get the top [1] things for you. If you must know, this happened: can't load karma")
 	})
 }
@@ -153,12 +153,12 @@ func TestErrorGettingKarmaWhenResetting(t *testing.T) {
 	mockStorer.On("ScanSilo", "myLittleChannel").Return(map[string]string{}, fmt.Errorf("can't load karma"))
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> reset"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> reset"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get delete karma for channel [myLittleChannel] for you. If you must know, this happened: can't load karma")
 	})
 }
@@ -171,12 +171,12 @@ func TestErrorDeletingKarmaWhenResetting(t *testing.T) {
 	mockStorer.On("DeleteSiloString", "myLittleChannel", "thing").Return(fmt.Errorf("can't delete"))
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> reset"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> reset"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get delete karma for channel [myLittleChannel] for you. If you must know, this happened: can't delete")
 	})
 }
@@ -188,12 +188,12 @@ func TestErrorGettingGlobalList(t *testing.T) {
 	mockStorer.On("GlobalScan").Return(map[string]map[string]string{}, fmt.Errorf("can't load karma"))
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "otherChan", Text: "<@bot> global top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "otherChan", Text: "<@bot> global top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get the global top [1] things for you. If you must know, this happened: can't load karma")
 	})
 }
@@ -205,12 +205,12 @@ func TestInvalidStoredKarmaValuesOnTopList(t *testing.T) {
 	mockStorer.On("ScanSilo", "myLittleChannel").Return(map[string]string{"thing": "abc"}, nil)
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get the top [1] things for you. If you must know, this happened: strconv.Atoi: parsing \"abc\": invalid syntax")
 	})
 }
@@ -222,12 +222,12 @@ func TestInvalidSingleStoredKarmaValuesOnGlobalTopList(t *testing.T) {
 	mockStorer.On("GlobalScan").Return(map[string]map[string]string{"myLittleChannel": map[string]string{"thing": "abc"}, "myOtherChannel": map[string]string{"thing": "1"}}, nil)
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "otherChannel", Text: "<@bot> global top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "otherChannel", Text: "<@bot> global top 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get the global top [1] things for you. If you must know, this happened: strconv.Atoi: parsing \"abc\": invalid syntax")
 	})
 }
@@ -239,12 +239,12 @@ func TestInvalidSingleStoredKarmaValuesOnGlobalWorstList(t *testing.T) {
 	mockStorer.On("GlobalScan").Return(map[string]map[string]string{"myLittleChannel": map[string]string{"thing": "1"}, "myOtherChannel": map[string]string{"thing": "abc"}}, nil)
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "otherChannel", Text: "<@bot> global worst 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "otherChannel", Text: "<@bot> global worst 1"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Sorry, I couldn't get the global worst [1] things for you. If you must know, this happened: strconv.Atoi: parsing \"abc\": invalid syntax")
 	})
 }
@@ -256,12 +256,12 @@ func TestLessItemsThanRequestedTopCountReturnsAllInOrder(t *testing.T) {
 	mockStorer.On("ScanSilo", "myLittleChannel").Return(map[string]string{"thing": "1", "bird": "2"}, nil)
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top 3"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top 3"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":leaves::leaves::leaves::trophy: *Top* :trophy::leaves::leaves::leaves:", false, false), nil, nil),
@@ -280,12 +280,12 @@ func TestGlobalTopFormattingAndKarmaMerging(t *testing.T) {
 	mockStorer.On("GlobalScan").Return(map[string]map[string]string{"myLittleChannel": map[string]string{"thing": "1", "@someone": "3"}, "myOtherChannel": map[string]string{"thing": "4"}}, nil)
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> global top 2"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> global top 2"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":leaves::leaves::leaves::trophy: *Global Top* :trophy::leaves::leaves::leaves:", false, false), nil, nil),
@@ -304,12 +304,12 @@ func TestTopFormatting(t *testing.T) {
 	mockStorer.On("ScanSilo", "myLittleChannel").Return(map[string]string{"thing": "-10", "@someone": "3", "birds": "9", "@alf": "10"}, nil)
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top 4"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top 4"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":leaves::leaves::leaves::trophy: *Top* :trophy::leaves::leaves::leaves:", false, false), nil, nil),
@@ -332,12 +332,12 @@ func TestTopListingWithoutRequestedCount(t *testing.T) {
 	mockStorer.On("ScanSilo", "myLittleChannel").Return(map[string]string{"thing": "-10", "@someone": "3", "birds": "9", "mountains": "8", "rivers": "9", "@alf": "10"}, nil)
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> top"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":leaves::leaves::leaves::trophy: *Top* :trophy::leaves::leaves::leaves:", false, false), nil, nil),
@@ -362,12 +362,12 @@ func TestGlobalTopListingWithoutRequestedCount(t *testing.T) {
 	mockStorer.On("GlobalScan").Return(map[string]map[string]string{"myLittleChannel": map[string]string{"thing": "-10", "@someone": "3", "birds": "9", "mountains": "8", "rivers": "9", "@alf": "10"}}, nil)
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> global top"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> global top"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":leaves::leaves::leaves::trophy: *Global Top* :trophy::leaves::leaves::leaves:", false, false), nil, nil),
@@ -392,12 +392,12 @@ func TestGlobalWorstFormattingAndKarmaMerging(t *testing.T) {
 	mockStorer.On("GlobalScan").Return(map[string]map[string]string{"myLittleChannel": map[string]string{"thing": "-4", "@someone": "-2"}, "myOtherChannel": map[string]string{"thing": "1"}}, nil)
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> global worst 2"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> global worst 2"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":fallen_leaf::fallen_leaf::fallen_leaf::space_invader: *Global Worst* :space_invader::fallen_leaf::fallen_leaf::fallen_leaf:", false, false), nil, nil),
@@ -416,12 +416,12 @@ func TestWorstFormatting(t *testing.T) {
 	mockStorer.On("ScanSilo", "myLittleChannel").Return(map[string]string{"thing": "-10", "@someone": "3", "birds": "9", "@alf": "10"}, nil)
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> worst 4"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> worst 4"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":fallen_leaf::fallen_leaf::fallen_leaf::space_invader: *Worst* :space_invader::fallen_leaf::fallen_leaf::fallen_leaf:", false, false), nil, nil),
@@ -444,12 +444,12 @@ func TestGlobalWorstListingWithoutRequestedCount(t *testing.T) {
 	mockStorer.On("GlobalScan").Return(map[string]map[string]string{"myLittleChannel": map[string]string{"thing": "10", "@someone": "-3", "birds": "-9", "mountains": "-8", "rivers": "-9", "@alf": "-10"}}, nil)
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> global worst"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> global worst"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":fallen_leaf::fallen_leaf::fallen_leaf::space_invader: *Global Worst* :space_invader::fallen_leaf::fallen_leaf::fallen_leaf:", false, false), nil, nil),
@@ -474,12 +474,12 @@ func TestWorstListingWithoutRequestedCount(t *testing.T) {
 	mockStorer.On("ScanSilo", "myLittleChannel").Return(map[string]string{"thing": "10", "@someone": "-3", "birds": "-9", "mountains": "-8", "rivers": "-9", "@alf": "-10"}, nil)
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> worst"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> worst"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":fallen_leaf::fallen_leaf::fallen_leaf::space_invader: *Worst* :space_invader::fallen_leaf::fallen_leaf::fallen_leaf:", false, false), nil, nil),
@@ -504,12 +504,12 @@ func TestLessItemsThanRequestedWorstCount(t *testing.T) {
 	mockStorer.On("ScanSilo", "myLittleChannel").Return(map[string]string{"thing": "1", "bird": "2"}, nil)
 
 	var userInfoFinder userInfoFinder
-	k := plugins.NewKarma(mockStorer)
-	k.UserInfoFinder = userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&k.Plugin, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> worst 3"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@bot> worst 3"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":fallen_leaf::fallen_leaf::fallen_leaf::space_invader: *Worst* :space_invader::fallen_leaf::fallen_leaf::fallen_leaf:", false, false), nil, nil),

--- a/plugins/ohmonday.go
+++ b/plugins/ohmonday.go
@@ -4,6 +4,7 @@ package plugins
 
 import (
 	"github.com/alexandre-normand/slackscot"
+	"github.com/alexandre-normand/slackscot/actions"
 	"github.com/alexandre-normand/slackscot/config"
 	"github.com/alexandre-normand/slackscot/plugin"
 	"github.com/alexandre-normand/slackscot/schedule"
@@ -81,14 +82,18 @@ type OhMonday struct {
 func NewOhMonday(c *config.PluginConfig) (p *slackscot.Plugin, err error) {
 	c.SetDefault(atTimeKey, defaultAtTime)
 
-	scheduleDefinition := schedule.Definition{Interval: 1, Unit: schedule.Weeks, Weekday: time.Monday.String(), AtTime: c.GetString(atTimeKey)}
-
 	o := new(OhMonday)
 	o.channels = c.GetStringSlice(ohMondayChannelIDsKey)
 
-	// TODO Come back to this and use to-be-added scheduled action fluent building api
 	o.Plugin = plugin.New(OhMondayPluginName).
-		WithScheduledAction(slackscot.ScheduledActionDefinition{Schedule: scheduleDefinition, Description: "Start the week off with a nice greeting", Action: o.sendGreeting}).
+		WithScheduledAction(actions.NewScheduledAction().
+			WithSchedule(schedule.New().
+				Every(time.Monday.String()).
+				AtTime(c.GetString(atTimeKey)).
+				Build()).
+			WithDescription("Start the week off with a nice greeting").
+			WithAction(o.sendGreeting).
+			Build()).
 		Build()
 
 	return o.Plugin, nil

--- a/plugins/ohmonday_test.go
+++ b/plugins/ohmonday_test.go
@@ -22,7 +22,7 @@ func TestSendValidGreetingEachTimeCalled(t *testing.T) {
 	assertplugin := assertplugin.New(t, "bot")
 
 	for i := 0; i < 100; i++ {
-		assertplugin.RunsOnSchedule(p, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "09:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
+		assertplugin.RunsOnSchedule(p, schedule.New().Every(time.Monday.String()).AtTime("09:00").Build(), func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
 			return assert.Contains(t, sentMsgs, "channel1") && assert.Len(t, sentMsgs["channel1"], 1) && assert.Contains(t, sentMsgs["channel1"][0], "https://") &&
 				assert.Contains(t, sentMsgs, "channel2") && assert.Len(t, sentMsgs["channel2"], 1) && assert.Contains(t, sentMsgs["channel2"][0], "https://")
 		})
@@ -37,7 +37,7 @@ func TestDefaultAtTime(t *testing.T) {
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
-	assertplugin.RunsOnSchedule(p, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "10:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
+	assertplugin.RunsOnSchedule(p, schedule.New().Every(time.Monday.String()).AtTime("10:00").Build(), func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
 		return true
 	})
 }
@@ -49,7 +49,7 @@ func TestMissingChannelIDs(t *testing.T) {
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
-	assertplugin.RunsOnSchedule(p, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "10:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
+	assertplugin.RunsOnSchedule(p, schedule.New().Every(time.Monday.String()).AtTime("10:00").Build(), func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
 		return assert.Empty(t, sentMsgs)
 	})
 }
@@ -62,7 +62,7 @@ func TestEmptyChannels(t *testing.T) {
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
-	assertplugin.RunsOnSchedule(p, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "10:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
+	assertplugin.RunsOnSchedule(p, schedule.New().Every(time.Monday.String()).AtTime("10:00").Build(), func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
 		return assert.Empty(t, sentMsgs)
 	})
 }
@@ -76,7 +76,7 @@ func TestAtTimeOverride(t *testing.T) {
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
-	assertplugin.RunsOnSchedule(p, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "11:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
+	assertplugin.RunsOnSchedule(p, schedule.New().Every(time.Monday.String()).AtTime("11:00").Build(), func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
 		return true
 	})
 }

--- a/plugins/ohmonday_test.go
+++ b/plugins/ohmonday_test.go
@@ -16,13 +16,13 @@ func TestSendValidGreetingEachTimeCalled(t *testing.T) {
 	pc.Set("channelIDs", []string{"channel1", "channel2"})
 	pc.Set("atTime", "09:00")
 
-	o, err := plugins.NewOhMonday(pc)
+	p, err := plugins.NewOhMonday(pc)
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
 
 	for i := 0; i < 100; i++ {
-		assertplugin.RunsOnSchedule(&o.Plugin, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "09:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
+		assertplugin.RunsOnSchedule(p, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "09:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
 			return assert.Contains(t, sentMsgs, "channel1") && assert.Len(t, sentMsgs["channel1"], 1) && assert.Contains(t, sentMsgs["channel1"][0], "https://") &&
 				assert.Contains(t, sentMsgs, "channel2") && assert.Len(t, sentMsgs["channel2"], 1) && assert.Contains(t, sentMsgs["channel2"][0], "https://")
 		})
@@ -33,11 +33,11 @@ func TestDefaultAtTime(t *testing.T) {
 	pc := viper.New()
 	pc.Set("channelIDs", "testChannel")
 
-	o, err := plugins.NewOhMonday(pc)
+	p, err := plugins.NewOhMonday(pc)
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
-	assertplugin.RunsOnSchedule(&o.Plugin, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "10:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
+	assertplugin.RunsOnSchedule(p, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "10:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
 		return true
 	})
 }
@@ -45,11 +45,11 @@ func TestDefaultAtTime(t *testing.T) {
 func TestMissingChannelIDs(t *testing.T) {
 	pc := viper.New()
 
-	o, err := plugins.NewOhMonday(pc)
+	p, err := plugins.NewOhMonday(pc)
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
-	assertplugin.RunsOnSchedule(&o.Plugin, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "10:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
+	assertplugin.RunsOnSchedule(p, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "10:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
 		return assert.Empty(t, sentMsgs)
 	})
 }
@@ -58,11 +58,11 @@ func TestEmptyChannels(t *testing.T) {
 	pc := viper.New()
 	pc.Set("channelIDs", "")
 
-	o, err := plugins.NewOhMonday(pc)
+	p, err := plugins.NewOhMonday(pc)
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
-	assertplugin.RunsOnSchedule(&o.Plugin, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "10:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
+	assertplugin.RunsOnSchedule(p, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "10:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
 		return assert.Empty(t, sentMsgs)
 	})
 }
@@ -72,11 +72,11 @@ func TestAtTimeOverride(t *testing.T) {
 	pc.Set("channelIDs", "testChannel")
 	pc.Set("atTime", "11:00")
 
-	o, err := plugins.NewOhMonday(pc)
+	p, err := plugins.NewOhMonday(pc)
 	assert.NoError(t, err)
 
 	assertplugin := assertplugin.New(t, "bot")
-	assertplugin.RunsOnSchedule(&o.Plugin, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "11:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
+	assertplugin.RunsOnSchedule(p, schedule.Definition{Interval: 1, Weekday: time.Monday.String(), Unit: schedule.Weeks, AtTime: "11:00"}, func(t *testing.T, sentMsgs map[string][]string, fileUploads []slack.FileUploadParameters) bool {
 		return true
 	})
 }

--- a/plugins/triggerer.go
+++ b/plugins/triggerer.go
@@ -124,16 +124,30 @@ func NewTriggerer(storer store.GlobalSiloStringStorer) (p *slackscot.Plugin) {
 	t.triggerRegexes = make(map[string]*regexp.Regexp)
 
 	t.Plugin = plugin.New(TriggererPluginName).
-		WithHearAction(
-			actions.New().Hidden().WithMatcher(t.matchTriggers).WithUsage("say something that includes the trigger").WithDescription("Stays alert to react on registered triggers and react accordingly").WithAnswerer(t.reactOnTriggers).Build(),
+		WithHearAction(actions.NewHearAction().
+			Hidden().
+			WithMatcher(t.matchTriggers).
+			WithUsage("say something that includes the trigger").
+			WithDescription("Stays alert to react on registered triggers and react accordingly").
+			WithAnswerer(t.reactOnTriggers).
+			Build(),
 		).
 		WithCommand(
-			actions.New().WithMatcher(matchNewStandardTrigger).WithUsage("trigger [anywhere] on <trigger string> with <reaction string>").WithDescription("Register a trigger which will instruct me to react with `reaction string` when someone says `trigger string`").WithAnswerer(t.registerStandardTrigger).Build(),
+			actions.NewCommand().
+				WithMatcher(matchNewStandardTrigger).
+				WithUsage("trigger [anywhere] on <trigger string> with <reaction string>").
+				WithDescription("Register a trigger which will instruct me to react with `reaction string` when someone says `trigger string`").
+				WithAnswerer(t.registerStandardTrigger).
+				Build(),
 		).
-		WithCommand(
-			actions.New().WithMatcher(matchDeleteStandardTrigger).WithUsage("forget trigger on <trigger string>").WithDescription("Delete a trigger on `trigger string`").WithAnswerer(t.deleteStandardTrigger).Build(),
+		WithCommand(actions.NewCommand().
+			WithMatcher(matchDeleteStandardTrigger).
+			WithUsage("forget trigger on <trigger string>").
+			WithDescription("Delete a trigger on `trigger string`").
+			WithAnswerer(t.deleteStandardTrigger).
+			Build(),
 		).
-		WithCommand(actions.New().
+		WithCommand(actions.NewCommand().
 			WithMatcher(func(m *slackscot.IncomingMessage) bool {
 				return strings.HasPrefix(m.NormalizedText, "list triggers")
 			}).
@@ -141,13 +155,21 @@ func NewTriggerer(storer store.GlobalSiloStringStorer) (p *slackscot.Plugin) {
 			WithDescription("Lists all registered triggers").
 			WithAnswerer(t.listStandardTriggers).
 			Build()).
-		WithCommand(
-			actions.New().WithMatcher(matchNewEmojiTrigger).WithUsage("emoji trigger [anywhere] on <trigger string> with <reaction emojis>").WithDescription("Register an emoji trigger which will instruct me to emoji react with `reaction emojis` when someone says `trigger string`").WithAnswerer(t.registerEmojiTrigger).Build(),
+		WithCommand(actions.NewCommand().
+			WithMatcher(matchNewEmojiTrigger).
+			WithUsage("emoji trigger [anywhere] on <trigger string> with <reaction emojis>").
+			WithDescription("Register an emoji trigger which will instruct me to emoji react with `reaction emojis` when someone says `trigger string`").
+			WithAnswerer(t.registerEmojiTrigger).
+			Build(),
 		).
-		WithCommand(
-			actions.New().WithMatcher(matchDeleteEmojiTrigger).WithUsage("forget emoji trigger on <trigger string>").WithDescription("Delete an emoji trigger on `trigger string`").WithAnswerer(t.deleteEmojiTrigger).Build(),
+		WithCommand(actions.NewCommand().
+			WithMatcher(matchDeleteEmojiTrigger).
+			WithUsage("forget emoji trigger on <trigger string>").
+			WithDescription("Delete an emoji trigger on `trigger string`").
+			WithAnswerer(t.deleteEmojiTrigger).
+			Build(),
 		).
-		WithCommand(actions.New().
+		WithCommand(actions.NewCommand().
 			WithMatcher(func(m *slackscot.IncomingMessage) bool {
 				return strings.HasPrefix(m.NormalizedText, "list emoji triggers")
 			}).

--- a/plugins/triggerer.go
+++ b/plugins/triggerer.go
@@ -132,13 +132,12 @@ func NewTriggerer(storer store.GlobalSiloStringStorer) (p *slackscot.Plugin) {
 			WithAnswerer(t.reactOnTriggers).
 			Build(),
 		).
-		WithCommand(
-			actions.NewCommand().
-				WithMatcher(matchNewStandardTrigger).
-				WithUsage("trigger [anywhere] on <trigger string> with <reaction string>").
-				WithDescription("Register a trigger which will instruct me to react with `reaction string` when someone says `trigger string`").
-				WithAnswerer(t.registerStandardTrigger).
-				Build(),
+		WithCommand(actions.NewCommand().
+			WithMatcher(matchNewStandardTrigger).
+			WithUsage("trigger [anywhere] on <trigger string> with <reaction string>").
+			WithDescription("Register a trigger which will instruct me to react with `reaction string` when someone says `trigger string`").
+			WithAnswerer(t.registerStandardTrigger).
+			Build(),
 		).
 		WithCommand(actions.NewCommand().
 			WithMatcher(matchDeleteStandardTrigger).
@@ -148,9 +147,7 @@ func NewTriggerer(storer store.GlobalSiloStringStorer) (p *slackscot.Plugin) {
 			Build(),
 		).
 		WithCommand(actions.NewCommand().
-			WithMatcher(func(m *slackscot.IncomingMessage) bool {
-				return strings.HasPrefix(m.NormalizedText, "list triggers")
-			}).
+			WithMatcher(func(m *slackscot.IncomingMessage) bool { return strings.HasPrefix(m.NormalizedText, "list triggers") }).
 			WithUsage("list triggers").
 			WithDescription("Lists all registered triggers").
 			WithAnswerer(t.listStandardTriggers).

--- a/plugins/triggerer_test.go
+++ b/plugins/triggerer_test.go
@@ -25,26 +25,26 @@ func TestRegisterNewTrigger(t *testing.T) {
 	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => `http://dealwithit.gif`]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "deal with nothing"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "deal with nothing"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, answers) && assert.Empty(t, emojis)
 		})
 
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "deal with itself"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "deal with itself"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, answers) && assert.Empty(t, emojis)
 		})
 
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://dealwithit.gif") && assertanswer.HasOptions(t, answers[0])
 		})
 
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://dealwithit.gif") && assertanswer.HasOptions(t, answers[0])
 		})
 
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "don't tell me to deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "don't tell me to deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://dealwithit.gif") && assertanswer.HasOptions(t, answers[0])
 		})
 
@@ -60,7 +60,7 @@ func TestTriggerReactionWithCollidingGlobalAndChannelTriggers(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://channel.gif") && assertanswer.HasOptions(t, answers[0])
 	})
 }
@@ -74,7 +74,7 @@ func TestTriggerReactionWithOnlyGlobalTrigger(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "otherChan", Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "otherChan", Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://global.gif") && assertanswer.HasOptions(t, answers[0])
 	})
 }
@@ -91,14 +91,14 @@ func TestRegisterNewMultilineReactionTrigger(t *testing.T) {
 	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> trigger on deal with it with ```{\n\"attributes\"=1.0\n}\n```"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> trigger on deal with it with ```{\n\"attributes\"=1.0\n}\n```"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new standard trigger [`deal with it` => ```{\n\"attributes\"=1.0\n}\n```]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "```{\n\"attributes\"=1.0\n}\n```") && assertanswer.HasOptions(t, answers[0])
 		})
 
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "```{\n\"attributes\"=1.0\n}\n```") && assertanswer.HasOptions(t, answers[0])
 		})
 	}
@@ -115,22 +115,22 @@ func TestRegisterNewEmojiTrigger(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> emoji trigger on deal with it with :boom::cat:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> emoji trigger on deal with it with :boom::cat:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Registered new emoji trigger [`deal with it` => :boom:, :cat:]") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "deal with nothing"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "deal with nothing"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, emojis) && assert.Empty(t, answers)
 		})
 
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "deal with itself"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "deal with itself"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, emojis) && assert.Empty(t, answers)
 		})
 
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, answers) && assert.Contains(t, emojis, "boom", "cat")
 		})
 
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "DEAL WITH IT"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, answers) && assert.Contains(t, emojis, "boom", "cat")
 		})
 	}
@@ -142,7 +142,7 @@ func TestRegisterNewEmojiTriggerWithoutEmojis(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> emoji trigger on deal with it with what are emojis?"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> emoji trigger on deal with it with what are emojis?"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Invalid reaction for emoji trigger: `<reaction emojis>` doesn't include any emojis") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	})
 }
@@ -158,7 +158,7 @@ func TestErrorGettingTriggersWhenReacting(t *testing.T) {
 	assertplugin := assertplugin.New(t, "bot")
 
 	// Validate trigger reaction is absent because of the error listing triggers
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers) && assert.Empty(t, emojis)
 	})
 }
@@ -174,7 +174,7 @@ func TestErrorGettingGlobalTriggersWhenReacting(t *testing.T) {
 	assertplugin := assertplugin.New(t, "bot")
 
 	// Validate trigger reaction is absent because of the error listing triggers
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers) && assert.Empty(t, emojis)
 	})
 }
@@ -221,7 +221,7 @@ func TestNoAnswersAndNoEmojisWhenNoTriggers(t *testing.T) {
 	triggerer := plugins.NewTriggerer(mockStorer)
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers) && assert.Empty(t, emojis)
 	})
 }
@@ -237,7 +237,7 @@ func TestErrorOnRegisterNewTrigger(t *testing.T) {
 	assertplugin := assertplugin.New(t, "bot")
 
 	// Register new trigger and get an error persisting it
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> trigger on deal with it with http://dealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error persisting standard trigger [`deal with it` => `http://dealwithit.gif`]: `Mock error`") &&
 			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	})
@@ -255,11 +255,11 @@ func TestUpdateTrigger(t *testing.T) {
 	triggerer := plugins.NewTriggerer(mockStorer)
 	assertplugin := assertplugin.New(t, "bot")
 
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> trigger on deal with it with http://betterdealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> trigger on deal with it with http://betterdealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Replaced standard trigger reaction for [`deal with it`] with [`http://betterdealwithit.gif`] (was [`http://dealwithit.gif`] previously)") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
 		// Validate updated trigger reaction
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "http://betterdealwithit.gif") && assertanswer.HasOptions(t, answers[0])
 		})
 	}
@@ -277,11 +277,11 @@ func TestUpdateEmojiTrigger(t *testing.T) {
 	triggerer := plugins.NewTriggerer(mockStorer)
 	assertplugin := assertplugin.New(t, "bot")
 
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> emoji trigger on deal with it with :boom:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> emoji trigger on deal with it with :boom:"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Replaced emoji trigger reaction for [`deal with it`] with [:boom:] (was [:man-in-suit:] previously)") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
 		// Validate updated trigger reaction
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, answers) && assert.Contains(t, emojis, "boom")
 		})
 	}
@@ -298,7 +298,7 @@ func TestErrorOnUpdateTrigger(t *testing.T) {
 	assertplugin := assertplugin.New(t, "bot")
 
 	// Attempt to update trigger and expect error message
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> trigger on deal with it with http://betterdealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> trigger on deal with it with http://betterdealwithit.gif"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error persisting standard trigger [`deal with it` => `http://betterdealwithit.gif`]: `Mock error`") &&
 			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	})
@@ -315,7 +315,7 @@ func TestDeleteTrigger(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Deleted standard trigger [`deal with it` => `http://dealwithit.gif`]") &&
 			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	})
@@ -334,7 +334,7 @@ func TestDeleteGlobalTrigger(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Deleted standard trigger [`deal with it` => `http://global.gif`]") &&
 			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	})
@@ -352,12 +352,12 @@ func TestDeleteEmojiTrigger(t *testing.T) {
 	triggerer := plugins.NewTriggerer(mockStorer)
 	assertplugin := assertplugin.New(t, "bot")
 
-	if assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> forget emoji trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	if assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> forget emoji trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Deleted emoji trigger [`deal with it` => :boom:]") &&
 			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	}) {
 		// Validate no reaction
-		assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 			return assert.Empty(t, emojis) && assert.Empty(t, answers)
 		})
 	}
@@ -375,7 +375,7 @@ func TestDeleteTriggerNotFound(t *testing.T) {
 	assertplugin := assertplugin.New(t, "bot")
 
 	// Delete trigger
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "No standard trigger found on `deal with it`") &&
 			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	})
@@ -391,7 +391,7 @@ func TestErrorOnDeleteTrigger(t *testing.T) {
 	triggerer := plugins.NewTriggerer(mockStorer)
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error removing standard trigger [`deal with it` => `http://dealwithit.gif`]: `Mock error`") &&
 			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	})
@@ -408,7 +408,7 @@ func TestErrorOnDeleteGlobalTrigger(t *testing.T) {
 	triggerer := plugins.NewTriggerer(mockStorer)
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> forget trigger on deal with it"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error removing standard trigger [`deal with it` => `http://funnygif.gif`]: `Mock error`") &&
 			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	})
@@ -425,7 +425,7 @@ func TestListTriggers(t *testing.T) {
 	assertplugin := assertplugin.New(t, "bot")
 
 	// List triggers
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> list triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> list triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the current triggers: \n     • `deal with it` => `http://dealwithit.gif`\n     • `suddenly`     => ```{\n\"attributes\"=1.0\n}\n```\n\n") &&
 			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	})
@@ -442,7 +442,7 @@ func TestListEmojiTriggers(t *testing.T) {
 	assertplugin := assertplugin.New(t, "bot")
 
 	// List triggers
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> list emoji triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> list emoji triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Here are the current emoji triggers: \n     • `deal with it` => :sunglasses:\n     • `suddenly`     => :scream:, :ghost:\n\n") &&
 			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	})
@@ -458,7 +458,7 @@ func TestErrorOnListTriggers(t *testing.T) {
 	assertplugin := assertplugin.New(t, "bot")
 
 	// List triggers
-	assertplugin.AnswersAndReacts(&triggerer.Plugin, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> list triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(triggerer, &slack.Msg{Channel: "myLittleChan", Text: "<@bot> list triggers"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, emojis) && assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Error loading triggers:\n```Mock error```") &&
 			assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.ThreadedReplyOpt, Value: "true"}, assertanswer.ResolvedAnswerOption{Key: slackscot.BroadcastOpt, Value: "false"})
 	})

--- a/plugins/versionner.go
+++ b/plugins/versionner.go
@@ -17,7 +17,7 @@ const (
 // NewVersionner creates a new instance of the versionner plugin
 func NewVersionner(name string, version string) (p *slackscot.Plugin) {
 	p = plugin.New(versionnerPluginName).
-		WithCommand(actions.New().
+		WithCommand(actions.NewCommand().
 			WithMatcher(func(m *slackscot.IncomingMessage) bool {
 				return strings.HasPrefix(m.NormalizedText, "version")
 			}).

--- a/plugins/versionner.go
+++ b/plugins/versionner.go
@@ -5,27 +5,28 @@ package plugins
 import (
 	"fmt"
 	"github.com/alexandre-normand/slackscot"
+	"github.com/alexandre-normand/slackscot/actions"
+	"github.com/alexandre-normand/slackscot/plugin"
 	"strings"
 )
 
-// Versioner holds the plugin data for the karma plugin
-type Versioner struct {
-	slackscot.Plugin
-}
-
 const (
-	versionerPluginName = "versionner"
+	versionnerPluginName = "versionner"
 )
 
-// NewVersionner creates a new instance of the versioner plugin
-func NewVersionner(name string, version string) *Versioner {
-	return &Versioner{Plugin: slackscot.Plugin{Name: versionerPluginName, Commands: []slackscot.ActionDefinition{{
-		Match: func(m *slackscot.IncomingMessage) bool {
-			return strings.HasPrefix(m.NormalizedText, "version")
-		},
-		Usage:       "version",
-		Description: fmt.Sprintf("Reply with `%s`'s `version` number", name),
-		Answer: func(m *slackscot.IncomingMessage) *slackscot.Answer {
-			return &slackscot.Answer{Text: fmt.Sprintf("I'm `%s`, version `%s`", name, version)}
-		}}}, HearActions: nil}}
+// NewVersionner creates a new instance of the versionner plugin
+func NewVersionner(name string, version string) (p *slackscot.Plugin) {
+	p = plugin.New(versionnerPluginName).
+		WithCommand(actions.New().
+			WithMatcher(func(m *slackscot.IncomingMessage) bool {
+				return strings.HasPrefix(m.NormalizedText, "version")
+			}).
+			WithUsage("version").
+			WithDescriptionf("Reply with `%s`'s `version` number", name).
+			WithAnswerer(func(m *slackscot.IncomingMessage) *slackscot.Answer {
+				return &slackscot.Answer{Text: fmt.Sprintf("I'm `%s`, version `%s`", name, version)}
+			}).
+			Build()).
+		Build()
+	return p
 }

--- a/plugins/versionner_test.go
+++ b/plugins/versionner_test.go
@@ -11,31 +11,31 @@ import (
 )
 
 func TestSendValidVersionMessage(t *testing.T) {
-	v := plugins.NewVersionner("little-red", "1.0.0")
-	assert.NotNil(t, v)
+	p := plugins.NewVersionner("little-red", "1.0.0")
+	assert.NotNil(t, p)
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&v.Plugin, &slack.Msg{Text: "<@bot> version"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "<@bot> version"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "I'm `little-red`, version `1.0.0`")
 	})
 }
 
 func TestMatchOnVersionCommand(t *testing.T) {
-	v := plugins.NewVersionner("little-red", "1.0.0")
-	assert.NotNil(t, v)
+	p := plugins.NewVersionner("little-red", "1.0.0")
+	assert.NotNil(t, p)
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(&v.Plugin, &slack.Msg{Text: "<@bot> version"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "<@bot> version"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1)
 	})
 
-	assertplugin.AnswersAndReacts(&v.Plugin, &slack.Msg{Text: "<@bot>  version"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "<@bot>  version"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 0)
 	})
 
-	assertplugin.AnswersAndReacts(&v.Plugin, &slack.Msg{Text: "<@bot> version "}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Text: "<@bot> version "}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Len(t, answers, 1)
 	})
 }

--- a/slackscot.go
+++ b/slackscot.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nlopes/slack"
 	"github.com/spf13/cast"
 	"github.com/spf13/viper"
+	"io"
 	"log"
 	"os"
 	"os/signal"
@@ -50,6 +51,9 @@ type Slackscot struct {
 
 	// Logger
 	log *sLogger
+
+	// Resources to close on shutdown
+	closers []io.Closer
 }
 
 // Plugin represents a plugin (its name, action definitions and slackscot injected services)
@@ -244,6 +248,7 @@ func New(name string, v *viper.Viper, options ...Option) (s *Slackscot, err erro
 	s.name = name
 	s.config = v
 	s.namespaceCommands = true
+	s.closers = make([]io.Closer, 0)
 	s.defaultAction = func(m *IncomingMessage) *Answer {
 		return &Answer{Text: fmt.Sprintf("I don't understand, ask me for \"%s\" to get a list of things I do", helpPluginName)}
 	}

--- a/slackscot.go
+++ b/slackscot.go
@@ -1,7 +1,3 @@
-// Package slackscot provides the building blocks to create a slack bot. It is
-// easily extendable via plugins that can combine commands, hear actions (listeners) as well
-// as scheduled actions. It also supports updating of triggered responses on message updates as well
-// as deleting triggered responses when the triggering messages are deleted by users.
 package slackscot
 
 import (

--- a/slackscot.go
+++ b/slackscot.go
@@ -261,6 +261,21 @@ func New(name string, v *viper.Viper, options ...Option) (s *Slackscot, err erro
 	return s, nil
 }
 
+// Close closes all closers of this slackscot. The first error that occurs
+// during a Close is returned but regardless, all closers are attempted
+// to be closed
+func (s *Slackscot) Close() (err error) {
+	for _, c := range s.closers {
+		if err == nil {
+			err = c.Close()
+		} else {
+			c.Close()
+		}
+	}
+
+	return err
+}
+
 // RegisterPlugin registers a plugin with the Slackscot engine. This should be invoked
 // prior to calling Run
 func (s *Slackscot) RegisterPlugin(p *Plugin) {

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -768,6 +768,7 @@ func runSlackscotWithIncomingEvents(t *testing.T, v *viper.Viper, plugin *Plugin
 
 	<-termination
 
+	s.Close()
 	return inMemoryChatDriver.sentMsgs, inMemoryChatDriver.updatedMsgs, inMemoryChatDriver.deletedMsgs, rtmSenderCaptor
 }
 

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.31.0"
+	VERSION = "1.32.0"
 )


### PR DESCRIPTION
## What is this about
Add fluent-apis for setting up:
 - actions: `gitHub.com/alexandre-normand/slackscot/actions`
 - plugins: `gitHub.com/alexandre-normand/slackscot/plugin`
 - schedules: `gitHub.com/alexandre-normand/slackscot/schedule`
 - bots: `gitHub.com/alexandre-normand/slackscot` (via `builder.go`)

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass