### PR TITLE
Remove Unnecessary Usage of test-reporter fork in Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,8 @@ go:
 env:  
   - GO111MODULE=on
 
-# This should be github.com/codeclimate/test-reporter when https://github.com/codeclimate/test-reporter/issues/378 is resolved
-# Right now, this uses a hack in this fork to remove the first part of a path (in our case 'v2/' when failing). With proper
-# support for Go modules, this hack wouldn't be required
 install:
-  - GO111MODULE=off go get github.com/alexandre-normand/test-reporter
+  - GO111MODULE=off go get github.com/codeclimate/test-reporter
 
 before_script:
   - test-reporter before-build
@@ -19,4 +16,4 @@ script:
   - go test -coverprofile c.out ./...
 
 after_script:
-  - test-reporter after-build --debug --exit-code $TRAVIS_TEST_RESULT
+  - test-reporter after-build --prefix github.com/alexandre-normand/slackscot/ --debug --exit-code $TRAVIS_TEST_RESULT


### PR DESCRIPTION
## What is this about
Remove forked `test-reporter` from travis configuration. This was needed at some point but it's not required anymore since the current version works fine with the stock `test-reporter`. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass