### PR TITLE
👻 Fix Help Showing Section Headers With No Actions to Show Because of Hidden Flag

### DIFF
--- a/help_internal_test.go
+++ b/help_internal_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 )
 
-func newPluginWithActionsOfAllTypes() (p *Plugin) {
+func newPluginWithActionsOfAllTypes(hidden bool) (p *Plugin) {
 	p = new(Plugin)
 	p.Name = "thank"
 	p.NamespaceCommands = true
 	p.Commands = []ActionDefinition{{
+		Hidden: hidden,
 		Match: func(m *IncomingMessage) bool {
 			return strings.HasPrefix(m.NormalizedText, "@user")
 		},
@@ -24,6 +25,7 @@ func newPluginWithActionsOfAllTypes() (p *Plugin) {
 		}}}
 
 	p.HearActions = []ActionDefinition{{
+		Hidden: hidden,
 		Match: func(m *IncomingMessage) bool {
 			return strings.Contains(m.NormalizedText, "chickadee")
 		},
@@ -33,14 +35,14 @@ func newPluginWithActionsOfAllTypes() (p *Plugin) {
 			return nil
 		}}}
 
-	p.ScheduledActions = []ScheduledActionDefinition{{Schedule: schedule.Definition{Interval: 30, Unit: schedule.Seconds}, Description: "Sends a heartbeat every 30 seconds", Action: func() {}}}
+	p.ScheduledActions = []ScheduledActionDefinition{{Hidden: hidden, Schedule: schedule.Definition{Interval: 30, Unit: schedule.Seconds}, Description: "Sends a heartbeat every 30 seconds", Action: func() {}}}
 
 	return p
 }
 
 func TestHelpWithNamespacingEnabled(t *testing.T) {
 	s, err := New("robert", config.NewViperWithDefaults())
-	s.RegisterPlugin(newPluginWithActionsOfAllTypes())
+	s.RegisterPlugin(newPluginWithActionsOfAllTypes(false))
 
 	require.NoError(t, err)
 
@@ -63,7 +65,7 @@ func TestHelpWithNamespacingEnabled(t *testing.T) {
 
 func TestHelpWithNamespacingDisabled(t *testing.T) {
 	s, err := New("robert", config.NewViperWithDefaults(), OptionNoPluginNamespacing())
-	s.RegisterPlugin(newPluginWithActionsOfAllTypes())
+	s.RegisterPlugin(newPluginWithActionsOfAllTypes(false))
 
 	require.NoError(t, err)
 
@@ -78,4 +80,20 @@ func TestHelpWithNamespacingDisabled(t *testing.T) {
 		"I currently support the following commands:\n\t• `<someone of something to thank>` - Format a thank you note\n\nAnd listen for the following:\n"+
 		"\t• `say `chickadee` and hear a chirp` - Chirp when hearing people talk about chickadees\n\nAnd do those things periodically:\n"+
 		"\t• [`thank`] `Every 30 seconds` (`Local`) - Sends a heartbeat every 30 seconds\n", a.Text)
+}
+
+func TestHelpWithHiddenActions(t *testing.T) {
+	s, err := New("robert", config.NewViperWithDefaults(), OptionNoPluginNamespacing())
+	s.RegisterPlugin(newPluginWithActionsOfAllTypes(true))
+
+	require.NoError(t, err)
+
+	help := s.newHelpPlugin("1.0.0")
+	help.UserInfoFinder = &userInfoFinder{}
+
+	cmd := help.Commands[0]
+	a := cmd.Answer(&IncomingMessage{NormalizedText: "help"})
+	require.NotNil(t, a)
+
+	assert.Equal(t, "🤝 You're `Daniel Quinn` and I'm `robert` (engine `v1.0.0`). I listen to the team's chat and provides automated functions :genie:.\n", a.Text)
 }

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.32.1"
+	VERSION = "1.32.2"
 )


### PR DESCRIPTION
## What is this about
The `help` would show section headers such as "I currently support the following commands" even when no visible command existed. The header would correctly not be visible if no commands existed but if all that did exist were `hidden` and there was nothing to show, the header would still be there with the awkwardly empty section.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass