### PR TITLE
📗 Add godoc Examples in assertanswer and assertplugin

### DIFF
--- a/test/assertanswer/assertanswer.go
+++ b/test/assertanswer/assertanswer.go
@@ -1,4 +1,17 @@
 // Package assertanswer provides testing functions to validate a plugin's answer
+//
+// This package is most useful when used in combination with github.com/alexandre-normand/slackscot/test/assertplugin but
+// can be used alone to test individual slackscot Actions.
+//
+// Example of a typical usage also using assertplugin:
+//    func TestPlugin(t *testing.T) {
+//        assertplugin := assertplugin.New(t, "bot")
+//        yourPlugin := newPlugin()
+//
+//        assertplugin.AnswersAndReacts(yourPlugin, &slack.Msg{Text: "are you up?"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+// 	          return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "I'm 😴, you?")
+//        }))
+//    }
 package assertanswer
 
 import (

--- a/test/assertplugin/assertplugin.go
+++ b/test/assertplugin/assertplugin.go
@@ -8,6 +8,16 @@
 // Users should take special care to use include <@botUserID> with the same botUserID with which the
 // plugin driver has been instantiated in the message text inputs to test commands (or include a
 // channel name that starts with D for direct channel testing)
+//
+// Example:
+//    func TestPlugin(t *testing.T) {
+//        assertplugin := assertplugin.New(t, "bot")
+//        yourPlugin := newPlugin()
+//
+//        assertplugin.AnswersAndReacts(yourPlugin, &slack.Msg{Text: "are you up?"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+// 	          return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "I'm 😴, you?")
+//        }))
+//    }
 package assertplugin
 
 import (


### PR DESCRIPTION
## What is this about
This adds `godoc` examples for `assertplugin` and `assertanswer` packages.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass