### PR TITLE
💅 Replace Context by Regular Text Blocks in Karma Reports

### DIFF
--- a/plugins/karma.go
+++ b/plugins/karma.go
@@ -361,10 +361,7 @@ func (k *Karma) formatList(pl pairList) (blocks []slack.Block) {
 // formatRankedElement formats one ranked element in a list. It adds 3 blocks: one for the rank (icon),
 // one for the ranked "thing" and one for its karma value. The 3 block objects are then wrapped in a context block
 func formatRankedElement(p pair, rank int) (block slack.Block) {
-	nameBlock := slack.NewTextBlockObject("mrkdwn", renderThingName(p.Key), false, false)
-	countBlock := slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("`%d`", p.Value), false, false)
-
-	return *slack.NewContextBlock("", *nameBlock, *countBlock)
+	return *slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("• %s `%d`", renderThingName(p.Key), p.Value), false, false), nil, nil)
 }
 
 // renderThingName renders a karma item by formatting a user id with the required symbols such that it looks

--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -265,8 +265,8 @@ func TestLessItemsThanRequestedTopCountReturnsAllInOrder(t *testing.T) {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":leaves::leaves::leaves::trophy: *Top* :trophy::leaves::leaves::leaves:", false, false), nil, nil),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "bird", false, false), *slack.NewTextBlockObject("mrkdwn", "`2`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "thing", false, false), *slack.NewTextBlockObject("mrkdwn", "`1`", false, false))}, answers[0].ContentBlocks)
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• bird `2`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• thing `1`", false, false), nil, nil)}, answers[0].ContentBlocks)
 	})
 }
 
@@ -286,8 +286,8 @@ func TestGlobalTopFormattingAndKarmaMerging(t *testing.T) {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":leaves::leaves::leaves::trophy: *Global Top* :trophy::leaves::leaves::leaves:", false, false), nil, nil),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "thing", false, false), *slack.NewTextBlockObject("mrkdwn", "`5`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "<@someone>", false, false), *slack.NewTextBlockObject("mrkdwn", "`3`", false, false))}, answers[0].ContentBlocks)
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• thing `5`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• <@someone> `3`", false, false), nil, nil)}, answers[0].ContentBlocks)
 	})
 }
 
@@ -307,10 +307,10 @@ func TestTopFormatting(t *testing.T) {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":leaves::leaves::leaves::trophy: *Top* :trophy::leaves::leaves::leaves:", false, false), nil, nil),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "<@alf>", false, false), *slack.NewTextBlockObject("mrkdwn", "`10`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "birds", false, false), *slack.NewTextBlockObject("mrkdwn", "`9`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "<@someone>", false, false), *slack.NewTextBlockObject("mrkdwn", "`3`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "thing", false, false), *slack.NewTextBlockObject("mrkdwn", "`-10`", false, false))}, answers[0].ContentBlocks)
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• <@alf> `10`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• birds `9`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• <@someone> `3`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• thing `-10`", false, false), nil, nil)}, answers[0].ContentBlocks)
 	})
 }
 
@@ -330,11 +330,11 @@ func TestTopListingWithoutRequestedCount(t *testing.T) {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":leaves::leaves::leaves::trophy: *Top* :trophy::leaves::leaves::leaves:", false, false), nil, nil),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "<@alf>", false, false), *slack.NewTextBlockObject("mrkdwn", "`10`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "birds", false, false), *slack.NewTextBlockObject("mrkdwn", "`9`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "rivers", false, false), *slack.NewTextBlockObject("mrkdwn", "`9`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "mountains", false, false), *slack.NewTextBlockObject("mrkdwn", "`8`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "<@someone>", false, false), *slack.NewTextBlockObject("mrkdwn", "`3`", false, false))}, answers[0].ContentBlocks)
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• <@alf> `10`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• birds `9`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• rivers `9`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• mountains `8`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• <@someone> `3`", false, false), nil, nil)}, answers[0].ContentBlocks)
 	})
 }
 
@@ -354,11 +354,11 @@ func TestGlobalTopListingWithoutRequestedCount(t *testing.T) {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":leaves::leaves::leaves::trophy: *Global Top* :trophy::leaves::leaves::leaves:", false, false), nil, nil),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "<@alf>", false, false), *slack.NewTextBlockObject("mrkdwn", "`10`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "birds", false, false), *slack.NewTextBlockObject("mrkdwn", "`9`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "rivers", false, false), *slack.NewTextBlockObject("mrkdwn", "`9`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "mountains", false, false), *slack.NewTextBlockObject("mrkdwn", "`8`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "<@someone>", false, false), *slack.NewTextBlockObject("mrkdwn", "`3`", false, false))}, answers[0].ContentBlocks)
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• <@alf> `10`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• birds `9`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• rivers `9`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• mountains `8`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• <@someone> `3`", false, false), nil, nil)}, answers[0].ContentBlocks)
 	})
 }
 
@@ -378,8 +378,8 @@ func TestGlobalWorstFormattingAndKarmaMerging(t *testing.T) {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":fallen_leaf::fallen_leaf::fallen_leaf::space_invader: *Global Worst* :space_invader::fallen_leaf::fallen_leaf::fallen_leaf:", false, false), nil, nil),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "thing", false, false), *slack.NewTextBlockObject("mrkdwn", "`-3`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "<@someone>", false, false), *slack.NewTextBlockObject("mrkdwn", "`-2`", false, false))}, answers[0].ContentBlocks)
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• thing `-3`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• <@someone> `-2`", false, false), nil, nil)}, answers[0].ContentBlocks)
 	})
 }
 
@@ -399,10 +399,10 @@ func TestWorstFormatting(t *testing.T) {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":fallen_leaf::fallen_leaf::fallen_leaf::space_invader: *Worst* :space_invader::fallen_leaf::fallen_leaf::fallen_leaf:", false, false), nil, nil),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "thing", false, false), *slack.NewTextBlockObject("mrkdwn", "`-10`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "<@someone>", false, false), *slack.NewTextBlockObject("mrkdwn", "`3`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "birds", false, false), *slack.NewTextBlockObject("mrkdwn", "`9`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "<@alf>", false, false), *slack.NewTextBlockObject("mrkdwn", "`10`", false, false))}, answers[0].ContentBlocks)
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• thing `-10`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• <@someone> `3`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• birds `9`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• <@alf> `10`", false, false), nil, nil)}, answers[0].ContentBlocks)
 	})
 }
 
@@ -422,11 +422,11 @@ func TestGlobalWorstListingWithoutRequestedCount(t *testing.T) {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":fallen_leaf::fallen_leaf::fallen_leaf::space_invader: *Global Worst* :space_invader::fallen_leaf::fallen_leaf::fallen_leaf:", false, false), nil, nil),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "<@alf>", false, false), *slack.NewTextBlockObject("mrkdwn", "`-10`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "rivers", false, false), *slack.NewTextBlockObject("mrkdwn", "`-9`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "birds", false, false), *slack.NewTextBlockObject("mrkdwn", "`-9`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "mountains", false, false), *slack.NewTextBlockObject("mrkdwn", "`-8`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "<@someone>", false, false), *slack.NewTextBlockObject("mrkdwn", "`-3`", false, false))}, answers[0].ContentBlocks)
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• <@alf> `-10`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• rivers `-9`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• birds `-9`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• mountains `-8`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• <@someone> `-3`", false, false), nil, nil)}, answers[0].ContentBlocks)
 	})
 }
 
@@ -446,11 +446,12 @@ func TestWorstListingWithoutRequestedCount(t *testing.T) {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":fallen_leaf::fallen_leaf::fallen_leaf::space_invader: *Worst* :space_invader::fallen_leaf::fallen_leaf::fallen_leaf:", false, false), nil, nil),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "<@alf>", false, false), *slack.NewTextBlockObject("mrkdwn", "`-10`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "rivers", false, false), *slack.NewTextBlockObject("mrkdwn", "`-9`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "birds", false, false), *slack.NewTextBlockObject("mrkdwn", "`-9`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "mountains", false, false), *slack.NewTextBlockObject("mrkdwn", "`-8`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "<@someone>", false, false), *slack.NewTextBlockObject("mrkdwn", "`-3`", false, false))}, answers[0].ContentBlocks)
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• <@alf> `-10`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• rivers `-9`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• birds `-9`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• mountains `-8`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• <@someone> `-3`", false, false), nil, nil),
+		}, answers[0].ContentBlocks)
 	})
 }
 
@@ -470,7 +471,7 @@ func TestLessItemsThanRequestedWorstCount(t *testing.T) {
 		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "") && assert.Equal(t, []slack.Block{
 			*slack.NewSectionBlock(
 				slack.NewTextBlockObject("mrkdwn", ":fallen_leaf::fallen_leaf::fallen_leaf::space_invader: *Worst* :space_invader::fallen_leaf::fallen_leaf::fallen_leaf:", false, false), nil, nil),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "thing", false, false), *slack.NewTextBlockObject("mrkdwn", "`1`", false, false)),
-			*slack.NewContextBlock("", *slack.NewTextBlockObject("mrkdwn", "bird", false, false), *slack.NewTextBlockObject("mrkdwn", "`2`", false, false))}, answers[0].ContentBlocks)
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• thing `1`", false, false), nil, nil),
+			*slack.NewSectionBlock(slack.NewTextBlockObject("mrkdwn", "• bird `2`", false, false), nil, nil)}, answers[0].ContentBlocks)
 	})
 }

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.32.3"
+	VERSION = "1.32.4"
 )


### PR DESCRIPTION
## What is this about
I wasn't so well-versed when I did the initial implementation of the karma reporting with `block kit` and I had wrongly used `context` blocks. This replaces context blocks by regular text content blocks.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass