### PR TITLE
🧮 Add AnswerEphemeral Option and a Few Karma Plugin Features

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -11,6 +11,8 @@ const (
 	BroadcastOpt = "broadcast"
 	// ThreadTimestamp is the name of the option indicating the explicit timestamp of the thread to reply to
 	ThreadTimestamp = "threadTimestamp"
+	// EphemeralAnswerToOpt marks an answer to be sent as an ephemeral message to the provided userID
+	EphemeralAnswerToOpt = "ephemeralMsgToUserID"
 )
 
 // Answer holds data of an Action's Answer: namely, its text and options
@@ -63,6 +65,13 @@ func AnswerInThreadWithoutBroadcast() func(sendOpts map[string]string) {
 func AnswerWithoutThreading() func(sendOpts map[string]string) {
 	return func(sendOpts map[string]string) {
 		sendOpts[ThreadedReplyOpt] = "false"
+	}
+}
+
+// AnswerEphemeral sends the answer as an ephemeral message to the provided userID
+func AnswerEphemeral(userID string) func(sendOpts map[string]string) {
+	return func(sendOpts map[string]string) {
+		sendOpts[EphemeralAnswerToOpt] = userID
 	}
 }
 

--- a/answer_test.go
+++ b/answer_test.go
@@ -18,6 +18,7 @@ func TestApplyAnswerOptions(t *testing.T) {
 		{"threadedReplyWithoutBroadcast", []slackscot.AnswerOption{slackscot.AnswerInThreadWithoutBroadcast()}, map[string]string{slackscot.ThreadedReplyOpt: "true", slackscot.BroadcastOpt: "false"}},
 		{"noThreading", []slackscot.AnswerOption{slackscot.AnswerWithoutThreading()}, map[string]string{slackscot.ThreadedReplyOpt: "false"}},
 		{"threadReplyOnExistingThread", []slackscot.AnswerOption{slackscot.AnswerInExistingThread("1000")}, map[string]string{slackscot.ThreadedReplyOpt: "true", slackscot.ThreadTimestamp: "1000"}},
+		{"ephemeralAnswer", []slackscot.AnswerOption{slackscot.AnswerEphemeral("U12321")}, map[string]string{slackscot.EphemeralAnswerToOpt: "U12321"}},
 	}
 
 	for _, tc := range testCases {

--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -39,8 +39,18 @@ func TestKarmaMatchesAndAnswers(t *testing.T) {
 		{"salmon++", "Cgeneral", "`salmon` just gained a level (`salmon`: 2)"},
 		{"salmon++", "Cgeneral", "`salmon` just gained a level (`salmon`: 3)"},
 		{"salmon++", "Cgeneral", "`salmon` just gained a level (`salmon`: 4)"},
+		{"salmon+++", "Cgeneral", "`salmon` just gained 2 levels (`salmon`: 6)"},
+		{"salmon++++", "Cgeneral", "`salmon` just gained 3 levels (`salmon`: 9)"},
+		{"salmon+++++", "Cgeneral", "`salmon` just gained 4 levels (`salmon`: 13)"},
+		{"salmon++++++", "Cgeneral", "`salmon` just gained 5 levels (`salmon`: 18)"},
+		{"salmon+++++++", "Cgeneral", "`salmon` just gained 5 levels (`salmon`: 23)"},
 		{"dams--", "Cgeneral", "`dams` just lost a life (`dams`: -1)"},
 		{"dams--", "Cgeneral", "`dams` just lost a life (`dams`: -2)"},
+		{"dams---", "Cgeneral", "`dams` just lost 2 lives (`dams`: -4)"},
+		{"dams----", "Cgeneral", "`dams` just lost 3 lives (`dams`: -7)"},
+		{"dams-----", "Cgeneral", "`dams` just lost 4 lives (`dams`: -11)"},
+		{"dams------", "Cgeneral", "`dams` just lost 5 lives (`dams`: -16)"},
+		{"dams-------", "Cgeneral", "`dams` just lost 5 lives (`dams`: -21)"},
 		{"<@bot> karma", "Cgeneral", ""},
 		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 1)"},
 		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 2)"},
@@ -108,6 +118,21 @@ func TestErrorStoringKarmaRecord(t *testing.T) {
 
 	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "thing++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers)
+	})
+}
+
+func TestInvalidSelfKarma(t *testing.T) {
+	mockStorer := &mockStorer{}
+	defer mockStorer.AssertExpectations(t)
+
+	var userInfoFinder userInfoFinder
+	p := plugins.NewKarma(mockStorer)
+	p.UserInfoFinder = userInfoFinder
+
+	assertplugin := assertplugin.New(t, "bot")
+
+	assertplugin.AnswersAndReacts(p, &slack.Msg{User: "U123", Channel: "myLittleChannel", Text: "<@U123>++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Attributing yourself karma is frown upon :face_with_raised_eyebrow:") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.EphemeralAnswerToOpt, Value: "U123"})
 	})
 }
 

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.32.4"
+	VERSION = "1.33.0"
 )


### PR DESCRIPTION
## What is this about
Add `AnswerEphemeral` answer option to have the `answer` be sent as an ephemeral message.

And a few `karma` features:
 - Ability to increment/decrement by more than 1 (up to 5) by using
   additional + or - signs
 - Block self attribution of karma and send ephemeral message
   to author to indicate behavior
 - Hide karma reset command to prevent abuse

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass