### PR TITLE
👻 Fix Ephemeral Answer Option Not Fully Propagated to Sent Message

### DIFF
--- a/slackscot.go
+++ b/slackscot.go
@@ -614,6 +614,11 @@ func (s *Slackscot) sendNewMessage(sender messageSender, o *OutgoingMessage, def
 		}
 	}
 
+	// Add ephemeral option if present
+	if userID, ok := sendOpts[EphemeralAnswerToOpt]; ok {
+		options = append(options, slack.MsgOptionPostEphemeral(userID))
+	}
+
 	// Add any block kit content blocks, if any
 	if len(o.ContentBlocks) > 0 {
 		options = append(options, slack.MsgOptionBlocks(o.ContentBlocks...))

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -159,7 +159,7 @@ func newTestPlugin() (tp *Plugin) {
 		Usage:       "make `<something>`",
 		Description: "Have the test bot make something for you",
 		Answer: func(m *IncomingMessage) *Answer {
-			return &Answer{Text: fmt.Sprintf("Make it yourself, @%s", m.User)}
+			return &Answer{Text: fmt.Sprintf("Make it yourself, @%s", m.User), Options: []AnswerOption{AnswerEphemeral(m.User)}}
 		},
 	},
 		{
@@ -472,11 +472,11 @@ func TestIncomingTriggeringMessageUpdatedToNotTriggerAnymore(t *testing.T) {
 func TestDirectMessageMatchingCommand(t *testing.T) {
 	sentMsgs, updatedMsgs, deletedMsgs, rtmSender, _ := runSlackscotWithIncomingEventsWithLogs(t, nil, newTestPlugin(), []slack.RTMEvent{
 		// Trigger the command action
-		newRTMMessageEvent(newMessageEvent("DFromUser", "make me happy", "Alphonse", timestamp1)),
+		newRTMMessageEvent(newMessageEvent("DFromUser", "noRules make me happy", "Alphonse", timestamp1)),
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 4, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "DFromUser", sentMsgs[0].channelID)
 	}
 
@@ -554,14 +554,14 @@ func TestIncomingTriggeringMessageUpdatedToTriggerDifferentAction(t *testing.T) 
 		// Trigger the hear action
 		newRTMMessageEvent(newMessageEvent("Cgeneral", "blue jays", "Alphonse", timestamp1)),
 		// Update the message to now trigger the command instead of the hear action
-		newRTMMessageEvent(newMessageEvent("Cgeneral", "blue jays", "Alphonse", timestamp2, optionChangedMessage(fmt.Sprintf("<@%s> make me laugh", botUserID), "Alphonse", timestamp1))),
+		newRTMMessageEvent(newMessageEvent("Cgeneral", "blue jays", "Alphonse", timestamp2, optionChangedMessage(fmt.Sprintf("<@%s> noRules make me laugh", botUserID), "Alphonse", timestamp1))),
 	})
 
 	if assert.Equal(t, 2, len(sentMsgs)) {
 		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
-		assert.Equal(t, 3, len(sentMsgs[1].msgOptions))
+		assert.Equal(t, 4, len(sentMsgs[1].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[1].channelID)
 	}
 

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.33.0"
+	VERSION = "1.33.1"
 )


### PR DESCRIPTION
## What is this about
`AnswerEphemeral` wasn't propagated to the `PostMessage` as it should have been. Added a test in `slackscot_test.go` for that and also fixed the test not exercising the `make` test command like it was supposed to. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass