### PR TITLE
🧼 Clean Up Option Function Signatures

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -31,14 +31,14 @@ type Answer struct {
 type AnswerOption func(sendOpts map[string]string)
 
 // AnswerInThread sets threaded replying
-func AnswerInThread() func(sendOpts map[string]string) {
+func AnswerInThread() AnswerOption {
 	return func(sendOpts map[string]string) {
 		sendOpts[ThreadedReplyOpt] = "true"
 	}
 }
 
 // AnswerInExistingThread sets threaded replying with the existing thread timestamp
-func AnswerInExistingThread(threadTimestamp string) func(sendOpts map[string]string) {
+func AnswerInExistingThread(threadTimestamp string) AnswerOption {
 	return func(sendOpts map[string]string) {
 		sendOpts[ThreadedReplyOpt] = "true"
 		sendOpts[ThreadTimestamp] = threadTimestamp
@@ -46,7 +46,7 @@ func AnswerInExistingThread(threadTimestamp string) func(sendOpts map[string]str
 }
 
 // AnswerInThreadWithBroadcast sets threaded replying with broadcast enabled
-func AnswerInThreadWithBroadcast() func(sendOpts map[string]string) {
+func AnswerInThreadWithBroadcast() AnswerOption {
 	return func(sendOpts map[string]string) {
 		sendOpts[ThreadedReplyOpt] = "true"
 		sendOpts[BroadcastOpt] = "true"
@@ -54,7 +54,7 @@ func AnswerInThreadWithBroadcast() func(sendOpts map[string]string) {
 }
 
 // AnswerInThreadWithoutBroadcast sets threaded replying with broadcast disabled
-func AnswerInThreadWithoutBroadcast() func(sendOpts map[string]string) {
+func AnswerInThreadWithoutBroadcast() AnswerOption {
 	return func(sendOpts map[string]string) {
 		sendOpts[ThreadedReplyOpt] = "true"
 		sendOpts[BroadcastOpt] = "false"
@@ -62,14 +62,14 @@ func AnswerInThreadWithoutBroadcast() func(sendOpts map[string]string) {
 }
 
 // AnswerWithoutThreading sets an answer to threading (and implicitly, broadcast) disabled
-func AnswerWithoutThreading() func(sendOpts map[string]string) {
+func AnswerWithoutThreading() AnswerOption {
 	return func(sendOpts map[string]string) {
 		sendOpts[ThreadedReplyOpt] = "false"
 	}
 }
 
 // AnswerEphemeral sends the answer as an ephemeral message to the provided userID
-func AnswerEphemeral(userID string) func(sendOpts map[string]string) {
+func AnswerEphemeral(userID string) AnswerOption {
 	return func(sendOpts map[string]string) {
 		sendOpts[EphemeralAnswerToOpt] = userID
 	}

--- a/fileuploader.go
+++ b/fileuploader.go
@@ -29,7 +29,7 @@ type UploadOption func(params *slack.FileUploadParameters)
 
 // UploadInThreadOption sets the file upload thread timestamp to an existing thread timestamp if
 // the incoming message triggering this is on an existing thread
-func UploadInThreadOption(m *IncomingMessage) func(params *slack.FileUploadParameters) {
+func UploadInThreadOption(m *IncomingMessage) UploadOption {
 	return func(p *slack.FileUploadParameters) {
 		if threadTimestamp, inThread := resolveThreadTimestamp(&m.Msg); inThread {
 			p.ThreadTimestamp = threadTimestamp

--- a/plugins/karma.go
+++ b/plugins/karma.go
@@ -166,7 +166,7 @@ func (k *Karma) recordKarma(message *slackscot.IncomingMessage) *slackscot.Answe
 	if len(thing) > 0 {
 		// Prevent a user from attributing karma to self
 		if strings.TrimPrefix(thing, "@") == message.User {
-			return &slackscot.Answer{Text: "Attributing yourself karma is frown upon :face_with_raised_eyebrow:", Options: []slackscot.AnswerOption{slackscot.AnswerEphemeral(message.User)}}
+			return &slackscot.Answer{Text: "*Attributing yourself karma is frown upon* :face_with_raised_eyebrow:", Options: []slackscot.AnswerOption{slackscot.AnswerEphemeral(message.User)}}
 		}
 	} else {
 		thing = match[2]

--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -132,7 +132,7 @@ func TestInvalidSelfKarma(t *testing.T) {
 	assertplugin := assertplugin.New(t, "bot")
 
 	assertplugin.AnswersAndReacts(p, &slack.Msg{User: "U123", Channel: "myLittleChannel", Text: "<@U123>++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "Attributing yourself karma is frown upon :face_with_raised_eyebrow:") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.EphemeralAnswerToOpt, Value: "U123"})
+		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "*Attributing yourself karma is frown upon* :face_with_raised_eyebrow:") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.EphemeralAnswerToOpt, Value: "U123"})
 	})
 }
 

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -116,7 +116,7 @@ func (sdb *ScheduleDefinitionBuilder) Build() Definition {
 type scheduleOption func(j *gocron.Job)
 
 // optionWeekday sets the weekday of a recurring job
-func optionWeekday(weekday string) func(j *gocron.Job) {
+func optionWeekday(weekday string) scheduleOption {
 	return func(j *gocron.Job) {
 		switch weekday {
 		case time.Monday.String():
@@ -138,7 +138,7 @@ func optionWeekday(weekday string) func(j *gocron.Job) {
 }
 
 // optionUnit sets the unit of a recurring job
-func optionUnit(unit IntervalUnit) func(j *gocron.Job) {
+func optionUnit(unit IntervalUnit) scheduleOption {
 	return func(j *gocron.Job) {
 		switch unit {
 		case Weeks:
@@ -156,7 +156,7 @@ func optionUnit(unit IntervalUnit) func(j *gocron.Job) {
 }
 
 // optionAtTime sets the AtTime of a recurring job
-func optionAtTime(atTime string) func(j *gocron.Job) {
+func optionAtTime(atTime string) scheduleOption {
 	return func(j *gocron.Job) {
 		j = j.At(atTime)
 	}

--- a/slackscot.go
+++ b/slackscot.go
@@ -203,7 +203,7 @@ type runDependencies struct {
 type Option func(*Slackscot)
 
 // OptionLog sets a logger for Slackscot
-func OptionLog(logger *log.Logger) func(*Slackscot) {
+func OptionLog(logger *log.Logger) Option {
 	return func(s *Slackscot) {
 		s.log.logger = logger
 	}
@@ -212,14 +212,14 @@ func OptionLog(logger *log.Logger) func(*Slackscot) {
 // OptionNoPluginNamespacing disables plugin command namespacing for this instance. This means
 // that namespacing plugin candidates will run without any extra plugin name matching required
 // This is useful to simplify command usage for instances running a single plugin
-func OptionNoPluginNamespacing() func(*Slackscot) {
+func OptionNoPluginNamespacing() Option {
 	return func(s *Slackscot) {
 		s.namespaceCommands = false
 	}
 }
 
 // OptionLogfile sets a logfile for Slackscot while using the other default logging prefix and options
-func OptionLogfile(logfile *os.File) func(*Slackscot) {
+func OptionLogfile(logfile *os.File) Option {
 	return func(s *Slackscot) {
 		s.log.logger = log.New(logfile, defaultLogPrefix, defaultLogFlag)
 	}

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -108,7 +108,7 @@ func (e *emojiReactor) AddReaction(name string, item slack.ItemRef) error {
 // Option type for building a message with additional options for specific test cases
 type testMsgOption func(e *slack.MessageEvent)
 
-func optionChangedMessage(text string, user string, originalTs string) func(e *slack.MessageEvent) {
+func optionChangedMessage(text string, user string, originalTs string) testMsgOption {
 	return func(e *slack.MessageEvent) {
 		e.SubType = "message_changed"
 		e.SubMessage = &slack.Msg{Text: text, User: user, Timestamp: originalTs}
@@ -121,7 +121,7 @@ func optionMessageReplied() func(e *slack.MessageEvent) {
 	}
 }
 
-func optionDeletedMessage(channelID string, timestamp string) func(e *slack.MessageEvent) {
+func optionDeletedMessage(channelID string, timestamp string) testMsgOption {
 	return func(e *slack.MessageEvent) {
 		e.SubType = "message_deleted"
 		e.DeletedTimestamp = timestamp
@@ -129,19 +129,19 @@ func optionDeletedMessage(channelID string, timestamp string) func(e *slack.Mess
 	}
 }
 
-func optionMessageOnThread(ts string) func(e *slack.MessageEvent) {
+func optionMessageOnThread(ts string) testMsgOption {
 	return func(e *slack.MessageEvent) {
 		e.ThreadTimestamp = ts
 	}
 }
 
-func optionDirectMessage(botUserID string) func(e *slack.MessageEvent) {
+func optionDirectMessage(botUserID string) testMsgOption {
 	return func(e *slack.MessageEvent) {
 		e.Channel = fmt.Sprintf("D%s", botUserID)
 	}
 }
 
-func optionPublicMessageToBot(botUserID string, channelID string) func(e *slack.MessageEvent) {
+func optionPublicMessageToBot(botUserID string, channelID string) testMsgOption {
 	return func(e *slack.MessageEvent) {
 		e.Channel = channelID
 		e.Text = fmt.Sprintf("<@%s> %s", botUserID, e.Text)

--- a/test/assertplugin/assertplugin.go
+++ b/test/assertplugin/assertplugin.go
@@ -61,7 +61,7 @@ type Option func(*Asserter)
 
 // OptionLog sets a logger for the asserter such that this logger is attached to the plugin when driven by
 // the asserter
-func OptionLog(logger *log.Logger) func(*Asserter) {
+func OptionLog(logger *log.Logger) Option {
 	return func(a *Asserter) {
 		a.logger = logger
 	}

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.33.1"
+	VERSION = "1.33.2"
 )


### PR DESCRIPTION
## What is this about

In an oversight that became a habit, the various implementation
of the Option pattern returning a function applying an Option on something
always used the explicit `func` signature instead of the defined type.

This change is purely with the syntax but it makes the code more readable.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass