### PR TITLE
🐌 Put Oh Monday Slow Tests Behind `slow` Flag and Have Travis Use It

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
 
 script:
   - go test -coverprofile c.out ./...
+  - go test ./plugins/ -slow
 
 after_script:
   - test-reporter after-build --prefix github.com/alexandre-normand/slackscot/ --debug --exit-code $TRAVIS_TEST_RESULT

--- a/plugins/ohmonday_internal_test.go
+++ b/plugins/ohmonday_internal_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"flag"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
@@ -12,17 +13,21 @@ const (
 	maxGifSizeInBytes = 10000000
 )
 
+var slow = flag.Bool("slow", false, "Enable execution of slow tests")
+
 // TestPicturesSmallerThan10MB checks that all urls are for GIFs smaller than 10MB
 // The main use is for contributions to the curated list to be confirmed by PR builds
 // to be of acceptable size
 func TestPicturesSmallerThan10MB(t *testing.T) {
-	for _, url := range mondayPictures {
-		t.Run(url, func(t *testing.T) {
-			size, err := getGifSize(url)
-			assert.Nil(t, err)
+	if *slow {
+		for _, url := range mondayPictures {
+			t.Run(url, func(t *testing.T) {
+				size, err := getGifSize(url)
+				assert.Nil(t, err)
 
-			assert.Conditionf(t, func() bool { return size <= maxGifSizeInBytes }, "Gif file size should be <= %d bytes but was %d bytes for [%s]", maxGifSizeInBytes, size, url)
-		})
+				assert.Conditionf(t, func() bool { return size <= maxGifSizeInBytes }, "Gif file size should be <= %d bytes but was %d bytes for [%s]", maxGifSizeInBytes, size, url)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
## What is this about
I just heard about the pattern of using `flags` in tests to control execution such as `slow` tests. I'm usually not a fan of extra complexity like this but it's perfect of the `Oh Monday` tests that validate that all curated links are below `10 MB`. It's not so much a functional test that we need to run during fast development but it's one we want to run in continuous integration to ensure we don't add links for too-large `gif`s. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass