### PR TITLE
😶 Fix Oh Monday Being Silent

### DIFF
--- a/chatdriver.go
+++ b/chatdriver.go
@@ -8,8 +8,11 @@ import (
 // The main purpose is a slight decoupling of the slack.RTM in order for plugins to be able to write
 // tests more easily if all they do is send new messages on a channel
 type RealTimeMessageSender interface {
-	// NewOutgoingMessage is the function that sends a new message to the specified channelID
+	// NewOutgoingMessage is the function that creates a new message to send. See https://godoc.org/github.com/nlopes/slack#RTM.NewOutgoingMessage for more details
 	NewOutgoingMessage(text string, channelID string, options ...slack.RTMsgOption) *slack.OutgoingMessage
+
+	// SendMessage is the function that sends a new real time message. See https://godoc.org/github.com/nlopes/slack#RTM.SendMessage for more details
+	SendMessage(outMsg *slack.OutgoingMessage)
 }
 
 // messageSender is implemented by any value that has the SendMessage method. Note that the difference between the RealTimeMessageSender

--- a/plugins/ohmonday.go
+++ b/plugins/ohmonday.go
@@ -104,6 +104,7 @@ func (o *OhMonday) sendGreeting() {
 		message := mondayPictures[selectionRandom.Intn(len(mondayPictures))]
 		o.Logger.Debugf("[%s] Sending morning greeting message [%s] to [%s]", OhMondayPluginName, message, c)
 
-		o.RealTimeMsgSender.NewOutgoingMessage(message, c)
+		om := o.RealTimeMsgSender.NewOutgoingMessage(message, c)
+		o.RealTimeMsgSender.SendMessage(om)
 	}
 }

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -680,7 +680,8 @@ func TestScheduledAction(t *testing.T) {
 	beatPlugin := new(Plugin)
 	beatPlugin.Name = "beat"
 	beatPlugin.ScheduledActions = []ScheduledActionDefinition{{Schedule: scheduleDefinition, Description: "Send a beat every second", Action: func() {
-		beatPlugin.RealTimeMsgSender.NewOutgoingMessage("beat", "Cstatus")
+		om := beatPlugin.RealTimeMsgSender.NewOutgoingMessage("beat", "Cstatus")
+		beatPlugin.RealTimeMsgSender.SendMessage(om)
 	}}}
 
 	sentMsgs, updatedMsgs, deletedMsgs, rtmSender, _ := runSlackscotWithIncomingEventsWithLogs(t, nil, beatPlugin, []slack.RTMEvent{

--- a/test/assertplugin/assertplugin_test.go
+++ b/test/assertplugin/assertplugin_test.go
@@ -83,7 +83,8 @@ func heyAnswerer(m *slackscot.IncomingMessage) *slackscot.Answer {
 }
 
 func (mlt *myLittleTester) healthStatus() {
-	mlt.RealTimeMsgSender.NewOutgoingMessage("healthy", "test")
+	om := mlt.RealTimeMsgSender.NewOutgoingMessage("healthy", "test")
+	mlt.RealTimeMsgSender.SendMessage(om)
 	mlt.FileUploader.UploadFile(slack.FileUploadParameters{Filename: "healthStatus.png", Filetype: "image/png", Title: "healthy"})
 }
 

--- a/test/capture/sendercaptor.go
+++ b/test/capture/sendercaptor.go
@@ -18,13 +18,17 @@ func NewRealTimeSender() (rtms *RealTimeSenderCaptor) {
 	return rtms
 }
 
-// NewOutgoingMessage captures the details of a sent message (the message itself and the channel it's sent to)
+// NewOutgoingMessage creates an approximation of a message to send (the message itself and the channel it's sent to)
 // The returned OutgoingMessage has only the channel ID and text set on it
 func (rtms *RealTimeSenderCaptor) NewOutgoingMessage(text string, channelID string, options ...slack.RTMsgOption) *slack.OutgoingMessage {
 	if _, ok := rtms.SentMessages[channelID]; !ok {
 		rtms.SentMessages[channelID] = make([]string, 0)
 	}
 
-	rtms.SentMessages[channelID] = append(rtms.SentMessages[channelID], text)
 	return &slack.OutgoingMessage{Channel: channelID, Text: text}
+}
+
+// SendMessage captures the sent message
+func (rtms *RealTimeSenderCaptor) SendMessage(outMsg *slack.OutgoingMessage) {
+	rtms.SentMessages[outMsg.Channel] = append(rtms.SentMessages[outMsg.Channel], outMsg.Text)
 }

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.35.0"
+	VERSION = "1.35.1"
 )


### PR DESCRIPTION
## What is this about
`Oh Monday` had been silent for a while. I knew this was related to a recent refactor but only got the time now to investigate. Turns out that the plugin was creating the message but never actually _sending_ it. In the process, I also found that the `RealTimeSenderCaptor` was reporting a message as _sent_ when it was actually just _created_ which was hiding this in tests. This fixes both issues.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass