### PR TITLE
🚿 Omit Ephemeral/Non-Updatable Messages from Tracked Responses 

### DIFF
--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.35.1"
+	VERSION = "1.35.2"
 )


### PR DESCRIPTION
## What is this about
In adding support for `ephemeral` answers, there were cases where the triggering message was edited which caused a message update to be attempted. Because ephemeral messages don't have a channel id assigned and can't be updated, this caused an error to be logged. This wasn't a big issue but this change makes it more explicit that unmodifiable message ids aren't going to be tried for updates. The new behavior would be a new ephemeral message.

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass