### PR TITLE
🤫 Ignore Updated Messages Older than 24 Hours

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 const (
 	TokenKey                    = "token"                                  // Slack token, string
 	DebugKey                    = "debug"                                  // Debug mode, boolean
+	MaxAgeHandledMessages       = "maxAgeHandledMessages"                  // The maximum age of messages before they are ignored (applicable for message updates)
 	ResponseCacheSizeKey        = "responseCacheSize"                      // Response cache size in number of entries, int
 	TimeLocationKey             = "timeLocation"                           // Time Location as understood by time.LoadLocation
 	ThreadedRepliesKey          = "replyBehavior.threadedReplies"          // Threaded replies mode (slackscot will respond to all triggering messages using threads), boolean
@@ -27,6 +28,7 @@ const (
 	timeLocationDefault             = "Local"
 	threadedRepliesDefault          = false
 	broadcastThreadedRepliesDefault = false
+	maxAgeHandledMessagesDefault    = time.Duration(24) * time.Hour
 )
 
 // ReplyBehavior holds flags to define the replying behavior (use threads or not and broadcast replies or not)
@@ -46,6 +48,7 @@ func NewViperWithDefaults() (v *viper.Viper) {
 	v.SetDefault(TimeLocationKey, timeLocationDefault)
 	v.SetDefault(ThreadedRepliesKey, threadedRepliesDefault)
 	v.SetDefault(BroadcastThreadedRepliesKey, broadcastThreadedRepliesDefault)
+	v.SetDefault(MaxAgeHandledMessages, maxAgeHandledMessagesDefault)
 
 	return v
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"testing"
+	"time"
 )
 
 func TestNewWithDefault(t *testing.T) {
@@ -15,6 +16,7 @@ func TestNewWithDefault(t *testing.T) {
 	assert.Equal(t, "Local", v.GetString(config.TimeLocationKey), "%s should be %s", config.TimeLocationKey, "Local")
 	assert.Equal(t, false, v.GetBool(config.ThreadedRepliesKey), "%s should be %t", config.ThreadedRepliesKey, false)
 	assert.Equal(t, false, v.GetBool(config.BroadcastThreadedRepliesKey), "%s should be %t", config.BroadcastThreadedRepliesKey, false)
+	assert.Equal(t, time.Duration(24)*time.Hour, v.GetDuration(config.MaxAgeHandledMessages), "%s should be %t", config.MaxAgeHandledMessages, time.Duration(24)*time.Hour)
 }
 
 func TestGetTimeLocationWithDefault(t *testing.T) {

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,7 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181030000716-a0a13e073c7b h1:Un5iKMvgLIGMzGM1mJWvi22FiMX9XB6/NOzYKoy66y8=
 golang.org/x/tools v0.0.0-20181030000716-a0a13e073c7b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/help.go
+++ b/help.go
@@ -62,10 +62,10 @@ func (h *helpPlugin) showHelp(m *IncomingMessage) *Answer {
 	if err != nil {
 		h.Logger.Debugf("Error getting user info for user id [%s] so skipping mentioning the name (it would be awkward): %v", userID, err)
 	} else {
-		fmt.Fprintf(&b, "🤝 You're `%s` and ", user.RealName)
+		fmt.Fprintf(&b, "🤝 Hi, `%s`! ", user.RealName)
 	}
 
-	fmt.Fprintf(&b, "I'm `%s` (engine `v%s`). I listen to the team's chat and provides automated functions :genie:.\n", h.name, h.slackscotVersion)
+	fmt.Fprintf(&b, "I'm `%s` (engine `v%s`) and I listen to the team's chat and provides automated functions :genie:.\n", h.name, h.slackscotVersion)
 
 	if lenCommands(h.commands) > 0 {
 		fmt.Fprintf(&b, "\nI currently support the following commands:\n")

--- a/help_internal_test.go
+++ b/help_internal_test.go
@@ -57,7 +57,7 @@ func TestHelpWithNamespacingEnabled(t *testing.T) {
 	a := cmd.Answer(&IncomingMessage{NormalizedText: "help"})
 	require.NotNil(t, a)
 
-	assert.Equal(t, "🤝 You're `Daniel Quinn` and I'm `robert` (engine `v1.0.0`). I listen to the team's chat and provides automated functions :genie:.\n\n"+
+	assert.Equal(t, "🤝 Hi, `Daniel Quinn`! I'm `robert` (engine `v1.0.0`) and I listen to the team's chat and provides automated functions :genie:.\n\n"+
 		"I currently support the following commands:\n\t• `thank <someone of something to thank>` - Format a thank you note\n\nAnd listen for the following:\n"+
 		"\t• `say `chickadee` and hear a chirp` - Chirp when hearing people talk about chickadees\n\nAnd do those things periodically:\n"+
 		"\t• [`thank`] `Every 30 seconds` (`Local`) - Sends a heartbeat every 30 seconds\n", a.Text)
@@ -76,7 +76,7 @@ func TestHelpWithNamespacingDisabled(t *testing.T) {
 	a := cmd.Answer(&IncomingMessage{NormalizedText: "help"})
 	require.NotNil(t, a)
 
-	assert.Equal(t, "🤝 You're `Daniel Quinn` and I'm `robert` (engine `v1.0.0`). I listen to the team's chat and provides automated functions :genie:.\n\n"+
+	assert.Equal(t, "🤝 Hi, `Daniel Quinn`! I'm `robert` (engine `v1.0.0`) and I listen to the team's chat and provides automated functions :genie:.\n\n"+
 		"I currently support the following commands:\n\t• `<someone of something to thank>` - Format a thank you note\n\nAnd listen for the following:\n"+
 		"\t• `say `chickadee` and hear a chirp` - Chirp when hearing people talk about chickadees\n\nAnd do those things periodically:\n"+
 		"\t• [`thank`] `Every 30 seconds` (`Local`) - Sends a heartbeat every 30 seconds\n", a.Text)
@@ -95,5 +95,5 @@ func TestHelpWithHiddenActions(t *testing.T) {
 	a := cmd.Answer(&IncomingMessage{NormalizedText: "help"})
 	require.NotNil(t, a)
 
-	assert.Equal(t, "🤝 You're `Daniel Quinn` and I'm `robert` (engine `v1.0.0`). I listen to the team's chat and provides automated functions :genie:.\n", a.Text)
+	assert.Equal(t, "🤝 Hi, `Daniel Quinn`! I'm `robert` (engine `v1.0.0`) and I listen to the team's chat and provides automated functions :genie:.\n", a.Text)
 }

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.35.2"
+	VERSION = "1.36.0"
 )


### PR DESCRIPTION
## What is this about
It can be awkward when a an old message getting updated (for example, from a job auto-archiving some content) causes a reaction. This adds the a max age threshold for message handling. Messages older than the max age (defaulting to 24 hours) are just ignored. This can be overridden by a `time.Duration` configuration via `maxAgeHandledMessages`. 

Also, this includes tests improvements to `slackscot_test.go` by using the new [UnsafeApplyMsgOptions](https://godoc.org/github.com/nlopes/slack#UnsafeApplyMsgOptions) to apply message options and assert that the content and options are as expected. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass