### PR TITLE
🔖 Fix Karma Registering Content Enclosed in Code Block or Code Element

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nlopes/slack v0.5.1-0.20190508220637-3970c759dead
 	github.com/pkg/errors v0.8.1
+	github.com/russross/blackfriday/v2 v2.0.1
 	github.com/spf13/cast v1.3.0
 	github.com/spf13/viper v1.3.1
 	github.com/stretchr/objx v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,7 +105,10 @@ github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=
@@ -126,6 +129,7 @@ github.com/shurcooL/issuesapp v0.0.0-20180602232740-048589ce2241/go.mod h1:NPpHK
 github.com/shurcooL/notifications v0.0.0-20181007000457-627ab5aea122/go.mod h1:b5uSkrEVM1jQUspwbixRBhaIjIzL2xazXp6kntxYle0=
 github.com/shurcooL/octicon v0.0.0-20181028054416-fa4f57f9efb2/go.mod h1:eWdoE5JD4R5UVWDucdOPg1g2fqQRq78IQa9zlOV1vpQ=
 github.com/shurcooL/reactions v0.0.0-20181006231557-f2e0b4ca5b82/go.mod h1:TCR1lToEk4d2s07G3XGfz2QrgHXg4RJBvjrOozvoWfk=
+github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 h1:/vdW8Cb7EXrkqWGufVMES1OH2sU9gKVb2n9/1y5NMBY=
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYEDaXHZDBsXlPCDqdhQuJkuw4NOtaxYe3xii4=
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=

--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -63,6 +63,8 @@ func TestKarmaMatchesAndAnswers(t *testing.T) {
 		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 6)"},
 		{"<@U21355> ++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 7)"},
 		{"thing ++", "Cgeneral", ""},
+		{"```block--```", "Cgeneral", ""},
+		{"`inlinecode--`", "Cgeneral", ""},
 		{"don't++", "Cgeneral", "`don't` just gained a level (`don't`: 1)"},
 		{"under-the-bridge++", "Cgeneral", "`the-bridge` just gained a level (`the-bridge`: 1)"},
 		{"Jean-Michel++", "Cgeneral", "`Jean-Michel` just gained a level (`Jean-Michel`: 1)"},
@@ -89,11 +91,10 @@ func TestKarmaMatchesAndAnswers(t *testing.T) {
 	p := plugins.NewKarma(storer)
 	p.UserInfoFinder = userInfoFinder
 
-	assertplugin := assertplugin.New(t, "bot")
-
 	if assert.NotNil(t, p) {
 		for _, tc := range testCases {
 			t.Run(tc.text, func(t *testing.T) {
+				assertplugin := assertplugin.New(t, "bot")
 				assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: tc.channel, Text: tc.text}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 					if len(tc.expectedAnswer) > 0 {
 						return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], tc.expectedAnswer)

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.36.0"
+	VERSION = "1.36.1"
 )


### PR DESCRIPTION
## What is this about
@jeffkole This fixes potentially awkward false positive karma recording for content enclosed a code block or inline code element. To do this, I integrated with `blackfriday` to parse the text as markdown (slack formatting can be considered a very limited subset of markdown) and only try matches against text nodes. 

I could see that also being useful in other plugins like `fingerquoter` so I might decide to integrate some markdown parsing in the `core` and add on to the `IncomingMessage`'s normalized text by passing in an additional parsed text elements. I'm not sure yet if just feeding plugins the text elements would be the right thing or not (could a plugin actually be _more_ interested in code blocks?) so I'm going to hold off doing something like that for now. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass