### PR TITLE
Fetch bot id from user profile

### DIFF
--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -113,7 +113,7 @@ type userInfoFinder struct {
 }
 
 func (u *userInfoFinder) GetUserInfo(userID string) (user *slack.User, err error) {
-	return &slack.User{ID: botUserID, RealName: "Daniel Quinn"}, nil
+	return &slack.User{ID: botUserID, Profile: slack.UserProfile{BotID: "b" + botUserID}, RealName: "Daniel Quinn"}, nil
 }
 
 type emojiReactor struct {

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -159,6 +159,12 @@ func optionDirectMessage(botUserID string) testMsgOption {
 	}
 }
 
+func optionBotID(botID string) testMsgOption {
+	return func(e *slack.MessageEvent) {
+		e.BotID = botID
+	}
+}
+
 func optionPublicMessageToBot(botUserID string, channelID string) testMsgOption {
 	return func(e *slack.MessageEvent) {
 		e.Channel = channelID
@@ -827,6 +833,17 @@ func TestIncomingMessageNotTriggeringResponse(t *testing.T) {
 func TestIncomingMessageFromOurselfIgnored(t *testing.T) {
 	sentMsgs, updatedMsgs, deletedMsgs, rtmSender, _ := runSlackscotWithIncomingEventsWithLogs(t, nil, newTestPlugin(), []slack.RTMEvent{
 		newRTMMessageEvent(newMessageEvent("Cgeneral", "blue jays are cool", botUserID, timestamp1)),
+	})
+
+	assert.Equal(t, 0, len(sentMsgs))
+	assert.Equal(t, 0, len(updatedMsgs))
+	assert.Equal(t, 0, len(deletedMsgs))
+	assert.Equal(t, 0, len(rtmSender.SentMessages))
+}
+
+func TestIncomingMessageFromOurselfWithBotIDIgnored(t *testing.T) {
+	sentMsgs, updatedMsgs, deletedMsgs, rtmSender, _ := runSlackscotWithIncomingEventsWithLogs(t, nil, newTestPlugin(), []slack.RTMEvent{
+		newRTMMessageEvent(newMessageEvent("Cgeneral", "blue jays are cool", "", timestamp1, optionBotID("b"+botUserID))),
 	})
 
 	assert.Equal(t, 0, len(sentMsgs))

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -281,12 +281,11 @@ func TestHandleIncomingMessageTriggeringResponse(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 2, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
@@ -301,7 +300,7 @@ func TestAnswerWithNamespacingDisabled(t *testing.T) {
 	}, nil, OptionNoPluginNamespacing())
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 4, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
@@ -318,12 +317,11 @@ func TestAnswerWithContentBlocks(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 4, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "<@Alphonse>: ", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 		assert.Equal(t, "[{\"type\":\"context\",\"elements\":{\"Elements\":[{\"type\":\"mrkdwn\",\"text\":\"hello you\"}]}}]", vals.Get("blocks"))
 	}
@@ -336,23 +334,21 @@ func TestAnswerUpdateWithContentBlocks(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 4, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "<@Alphonse>: ", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 		assert.Equal(t, "[{\"type\":\"context\",\"elements\":{\"Elements\":[{\"type\":\"mrkdwn\",\"text\":\"hello you\"}]}}]", vals.Get("blocks"))
 	}
 
 	if assert.Equal(t, 1, len(updatedMsgs)) {
-		assert.Equal(t, 4, len(updatedMsgs[0].msgOptions))
+		assert.Equal(t, 3, len(updatedMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", updatedMsgs[0].channelID)
 
 		vals := applySlackOptions(updatedMsgs[0].msgOptions...)
 		assert.Equal(t, "<@Alphonse>: ", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 		assert.Equal(t, "[{\"type\":\"context\",\"elements\":{\"Elements\":[{\"type\":\"mrkdwn\",\"text\":\"hello you and everyone else\"}]}}]", vals.Get("blocks"))
 	}
@@ -364,12 +360,11 @@ func TestHandleIncomingThreadedMessageTriggeringResponse(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 4, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 		assert.Equal(t, "1212314125", vals.Get("thread_ts"))
 	}
@@ -415,22 +410,20 @@ func TestIncomingMessageUpdateTriggeringResponseUpdate(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 2, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
 	if assert.Equal(t, 1, len(updatedMsgs)) {
-		assert.Equal(t, 3, len(updatedMsgs[0].msgOptions))
+		assert.Equal(t, 2, len(updatedMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", updatedMsgs[0].channelID)
 
 		vals := applySlackOptions(updatedMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
@@ -446,18 +439,16 @@ func TestIncomingMessageUpdateNotTriggeringUpdateIfDifferentChannel(t *testing.T
 
 	// Check that the messages are distincts and not a message update given they were on different channels
 	if assert.Equal(t, 2, len(sentMsgs)) {
-		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 2, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 
-		assert.Equal(t, 3, len(sentMsgs[1].msgOptions))
+		assert.Equal(t, 2, len(sentMsgs[1].msgOptions))
 		assert.Equal(t, "Cother", sentMsgs[1].channelID)
 		vals = applySlackOptions(sentMsgs[1].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
@@ -480,23 +471,21 @@ func TestThreadedReplies(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 4, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 		assert.Equal(t, timestamp1, vals.Get("thread_ts"))
 	}
 
 	if assert.Equal(t, 1, len(updatedMsgs)) {
-		assert.Equal(t, 3, len(updatedMsgs[0].msgOptions))
+		assert.Equal(t, 2, len(updatedMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", updatedMsgs[0].channelID)
 
 		vals := applySlackOptions(updatedMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
@@ -518,24 +507,22 @@ func TestThreadedRepliesWithBroadcast(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 5, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 4, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 		assert.Equal(t, timestamp1, vals.Get("thread_ts"))
 		assert.Equal(t, "true", vals.Get("reply_broadcast"))
 	}
 
 	if assert.Equal(t, 1, len(updatedMsgs)) {
-		assert.Equal(t, 3, len(updatedMsgs[0].msgOptions))
+		assert.Equal(t, 2, len(updatedMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", updatedMsgs[0].channelID)
 
 		vals := applySlackOptions(updatedMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
@@ -551,12 +538,11 @@ func TestIncomingMessageTriggeringNewResponse(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 2, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
@@ -572,12 +558,11 @@ func TestIncomingTriggeringMessageUpdatedToNotTriggerAnymore(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 2, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
@@ -598,12 +583,11 @@ func TestDirectMessageMatchingCommand(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 4, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "DFromUser", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "Make it yourself, @Alphonse", vals.Get("text"))
-		assert.Equal(t, "Alphonse", vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 		assert.Equal(t, "", vals.Get("thread_ts"))
 	}
@@ -620,12 +604,11 @@ func TestDirectMessageNotMatchingAnything(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 2, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "DFromUser", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "I don't understand. Ask me for \"help\" to get a list of things I do", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 		assert.Equal(t, "", vals.Get("thread_ts"))
 	}
@@ -642,12 +625,11 @@ func TestDefaultCommandAnswerInChannel(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 2, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "<@Alphonse>: I don't understand. Ask me for \"help\" to get a list of things I do", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
@@ -663,12 +645,11 @@ func TestDefaultCommandAnswerToMsgOnExistingThread(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 4, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "<@Alphonse>: I don't understand. Ask me for \"help\" to get a list of things I do", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 		assert.Equal(t, "1212314125", vals.Get("thread_ts"))
 	}
@@ -685,12 +666,11 @@ func TestAtMessageNotMatchingAnything(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 2, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "<@Alphonse>: I don't understand. Ask me for \"help\" to get a list of things I do", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
@@ -708,18 +688,16 @@ func TestIncomingTriggeringMessageUpdatedToTriggerDifferentAction(t *testing.T) 
 	})
 
 	if assert.Equal(t, 2, len(sentMsgs)) {
-		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 2, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 
-		assert.Equal(t, 4, len(sentMsgs[1].msgOptions))
+		assert.Equal(t, 3, len(sentMsgs[1].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[1].channelID)
 		vals = applySlackOptions(sentMsgs[1].msgOptions...)
 		assert.Equal(t, "<@Alphonse>: Make it yourself, @Alphonse", vals.Get("text"))
-		assert.Equal(t, "Alphonse", vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
@@ -743,18 +721,16 @@ func TestMessageUpdateNoUpdateToEphemeralAnswer(t *testing.T) {
 	})
 
 	if assert.Equal(t, 2, len(sentMsgs)) {
-		assert.Equal(t, 4, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "<@Alphonse>: Make it yourself, @Alphonse", vals.Get("text"))
-		assert.Equal(t, "Alphonse", vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 
-		assert.Equal(t, 4, len(sentMsgs[1].msgOptions))
+		assert.Equal(t, 3, len(sentMsgs[1].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[1].channelID)
 		vals = applySlackOptions(sentMsgs[1].msgOptions...)
 		assert.Equal(t, "<@Alphonse>: Make it yourself, @Alphonse", vals.Get("text"))
-		assert.Equal(t, "Alphonse", vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
@@ -781,25 +757,23 @@ func testHelpTriggering(t *testing.T, v *viper.Viper) {
 	})
 
 	if assert.Equal(t, 2, len(sentMsgs)) {
-		assert.Equal(t, 4, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, fmt.Sprintf("<@Alphonse>: 🤝 Hi, `Daniel Quinn`! I'm `chickadee` (engine `v%s`) and I listen to the team's "+
 			"chat and provides automated functions :genie:.\n\nI currently support the following commands:\n\t• `noRules make `<something>`` - "+
 			"Have the test bot make something for you\n\t• `noRules block `<something>`` - Render your expression as a context block\n"+
 			"\t• `noRules create channel <name>` - Creates a new channel with the given name\n", VERSION), vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 		assert.Equal(t, timestamp1, vals.Get("thread_ts"))
 
-		assert.Equal(t, 3, len(sentMsgs[1].msgOptions))
+		assert.Equal(t, 2, len(sentMsgs[1].msgOptions))
 		assert.Equal(t, "DFromAlphonse", sentMsgs[1].channelID)
 		vals = applySlackOptions(sentMsgs[1].msgOptions...)
 		assert.Equal(t, fmt.Sprintf("🤝 Hi, `Daniel Quinn`! I'm `chickadee` (engine `v%s`) and I listen to the team's "+
 			"chat and provides automated functions :genie:.\n\nI currently support the following commands:\n\t• `noRules make `<something>`` - "+
 			"Have the test bot make something for you\n\t• `noRules block `<something>`` - Render your expression as a context block\n"+
 			"\t• `noRules create channel <name>` - Creates a new channel with the given name\n", VERSION), vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
@@ -824,12 +798,10 @@ func TestIncomingMessageUpdateTriggeringResponseDeletion(t *testing.T) {
 	})
 
 	if assert.Equal(t, 1, len(sentMsgs)) {
-		assert.Equal(t, 3, len(sentMsgs[0].msgOptions))
+		assert.Equal(t, 2, len(sentMsgs[0].msgOptions))
 		assert.Equal(t, "Cgeneral", sentMsgs[0].channelID)
-
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
@@ -907,7 +879,6 @@ func TestMessageUpdatedAfterHandlingThresholdIgnored(t *testing.T) {
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 
@@ -932,7 +903,7 @@ func TestMessageUpdatedHandledWhenUnableToCalculateAge(t *testing.T) {
 
 		vals := applySlackOptions(sentMsgs[0].msgOptions...)
 		assert.Equal(t, "I heard you say something about blue jays?", vals.Get("text"))
-		assert.Equal(t, botUserID, vals.Get("user"))
+
 		assert.Equal(t, "true", vals.Get("as_user"))
 	}
 

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.37.0"
+	VERSION = "1.37.1"
 )


### PR DESCRIPTION
## What is this about
@Dasio This adds retrieval of the `bot`'s user profile to include filtering on the `BotID`. This should make the self detection more robust. It would be great if you could try with this version and confirm that you don't get the original problem you reported in https://github.com/alexandre-normand/slackscot/issues/138. 🙇 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass