### PR TITLE
Command Prefix Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 
+# go mod vendor directory
+/vendor

--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ You know, a friendly company *mascot* that hangs out on your `slack`.
 *   `Commands`: commands are well-defined actions with a format. `Slackscot` 
     handles all direct messages as implicit commands as well as 
     `@mention <command>` on channels. Responses to commands are directed 
-    to the person who invoked it.
+    to the person who invoked it. If the `command-prefix` configuration option
+    is defined then any messages that begin with the `command-prefix` are
+    treated as commands.        
 
 *   `Hear actions`: those are listeners that can potentially match on any 
     message sent on channels that `slackscot` is a member of. This can 
@@ -251,6 +253,7 @@ which means that you are free to use a different file format
    "maxAgeHandledMessages": 86400,
    "timeLocation": "America/Los_Angeles",
    "storagePath": "/your-path-to-bot-home",
+   "command-prefix": "!!",
    "replyBehavior": {
       "threadedReplies": true,
       "broadcastThreadedReplies": true

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -1119,3 +1119,113 @@ func sendTestEventsForProcessing(ec chan<- slack.RTMEvent, events []slack.RTMEve
 	// Terminate the sequence of test events by sending a termination event
 	ec <- slack.RTMEvent{"disconnected", &slack.DisconnectedEvent{Intentional: true, Cause: slack.ErrRTMGoodbye}}
 }
+
+// Validate direct message handling
+func Test_isCommand0(t *testing.T) {
+	dmMessage := &slack.Msg{
+		Channel: "D12345",
+		Text:    "example DM",
+	}
+	isCmd, isDM := isCommand(dmMessage, "<@BOT123>", "!!")
+	assert.Truef(t, isDM, "Expected message to be a DM: CMD=%v,DM=%v", isCmd, isDM)
+	assert.Truef(t, isCmd, "Expected message to be a command: CMD=%v,DM=%v", isCmd, isDM)
+}
+
+// Validate direct message handling (neg)
+func Test_isCommand1(t *testing.T) {
+	dmMessage := &slack.Msg{
+		Channel: "C12345",
+		Text:    "example not a DM",
+	}
+	isCmd, isDM := isCommand(dmMessage, "<@BOT123>", "!!")
+	assert.Falsef(t, isDM, "Expected message to not be a DM: CMD=%v,DM=%v", isCmd, isDM)
+	assert.Falsef(t, isCmd, "Expected message to not be a command: CMD=%v,DM=%v", isCmd, isDM)
+}
+
+// Validate @mention handling
+func Test_isCommand2(t *testing.T) {
+	dmMessage := &slack.Msg{
+		Channel: "C12345",
+		Text:    "<@BOT123> example at mention",
+	}
+	isCmd, isDM := isCommand(dmMessage, "<@BOT123>", "")
+	assert.Falsef(t, isDM, "Expected message to not be a DM: CMD=%v,DM=%v", isCmd, isDM)
+	assert.Truef(t, isCmd, "Expected message to be a command: CMD=%v,DM=%v", isCmd, isDM)
+}
+
+// Validate @mention handling (neg)
+func Test_isCommand3(t *testing.T) {
+	dmMessage := &slack.Msg{
+		Channel: "C12345",
+		Text:    "<@BOT1234> example at mention",
+	}
+	isCmd, isDM := isCommand(dmMessage, "<@BOT123>", "")
+	assert.Falsef(t, isDM, "Expected message to not be a DM: CMD=%v,DM=%v", isCmd, isDM)
+	assert.Falsef(t, isCmd, "Expected message to be a command: CMD=%v,DM=%v", isCmd, isDM)
+}
+
+// Validate @mention handling (neg)
+func Test_isCommand4(t *testing.T) {
+	dmMessage := &slack.Msg{
+		Channel: "C12345",
+		Text:    "<@BOT123> example at mention",
+	}
+	isCmd, isDM := isCommand(dmMessage, "<@BOT1234>", "")
+	assert.Falsef(t, isDM, "Expected message to not be a DM: CMD=%v,DM=%v", isCmd, isDM)
+	assert.Falsef(t, isCmd, "Expected message to be a command: CMD=%v,DM=%v", isCmd, isDM)
+}
+
+// Validate prefix handling
+func Test_isCommand5(t *testing.T) {
+	dmMessage := &slack.Msg{
+		Channel: "C12345",
+		Text:    "!!example command",
+	}
+	isCmd, isDM := isCommand(dmMessage, "<@BOT123>", "!!")
+	assert.Falsef(t, isDM, "Expected message to not be a DM: CMD=%v,DM=%v", isCmd, isDM)
+	assert.Truef(t, isCmd, "Expected message to be a command: CMD=%v,DM=%v", isCmd, isDM)
+}
+
+// Validate prefix handling (neg)
+func Test_isCommand6(t *testing.T) {
+	dmMessage := &slack.Msg{
+		Channel: "C12345",
+		Text:    "!example command",
+	}
+	isCmd, isDM := isCommand(dmMessage, "<@BOT123>", "!!")
+	assert.Falsef(t, isDM, "Expected message to not be a DM: CMD=%v,DM=%v", isCmd, isDM)
+	assert.Falsef(t, isCmd, "Expected message to be a command: CMD=%v,DM=%v", isCmd, isDM)
+}
+
+// Validate prefix handling (neg)
+func Test_isCommand7(t *testing.T) {
+	dmMessage := &slack.Msg{
+		Channel: "C12345",
+		Text:    "example command",
+	}
+	isCmd, isDM := isCommand(dmMessage, "<@BOT123>", "!!")
+	assert.Falsef(t, isDM, "Expected message to not be a DM: CMD=%v,DM=%v", isCmd, isDM)
+	assert.Falsef(t, isCmd, "Expected message to be a command: CMD=%v,DM=%v", isCmd, isDM)
+}
+
+// Validate @mention with prefix
+func Test_isCommand8(t *testing.T) {
+	dmMessage := &slack.Msg{
+		Channel: "C12345",
+		Text:    "<@BOT123> !!example command",
+	}
+	isCmd, isDM := isCommand(dmMessage, "<@BOT123>", "!!")
+	assert.Falsef(t, isDM, "Expected message to not be a DM: CMD=%v,DM=%v", isCmd, isDM)
+	assert.Truef(t, isCmd, "Expected message to be a command: CMD=%v,DM=%v", isCmd, isDM)
+}
+
+// Validate @mention with prefix in DM
+func Test_isCommand9(t *testing.T) {
+	dmMessage := &slack.Msg{
+		Channel: "D12345",
+		Text:    "<@BOT123> !!example command",
+	}
+	isCmd, isDM := isCommand(dmMessage, "<@BOT123>", "!!")
+	assert.Truef(t, isDM, "Expected message to not be a DM: CMD=%v,DM=%v", isCmd, isDM)
+	assert.Truef(t, isCmd, "Expected message to be a command: CMD=%v,DM=%v", isCmd, isDM)
+}


### PR DESCRIPTION
## What is this about
Adds support for using a configurable prefix for commands. This is used in addition to DM/@mention support. 

This PR also adds the `vendor` directory to `.gitignore` and adds an excessive number of unit tests for `slackscot.isCommand`. 

### Ideas For Improvements
* Condense unit tests a bit
* Allow for multiple command prefixes by making the `isCommand` function to be passed in via arg to `NewSlackscot` and/or per plugin. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass
*   [ ] Test that it works with a real bot