### PR TITLE
Enable async processing of messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
 - [The Name](#the-name)
 - [Concepts](#concepts)
 - [Create Your Own Slackscot](#create-your-own-slackscot)
-	- [Assembling the Parts and Bringing Your `slackscot` to Life](#assembling-the-parts-and-bringing-your-slackscot-to-life)
-	- [Configuration Example](#configuration-example)
-	- [Creating Your Own Plugins](#creating-your-own-plugins)
+  - [Assembling the Parts and Bringing Your `slackscot` to Life](#assembling-the-parts-and-bringing-your-slackscot-to-life)
+  - [Configuration Example](#configuration-example)
+  - [Creating Your Own Plugins](#creating-your-own-plugins)
 - [Contributing](#contributing)
 - [Some Credits](#some-credits)
 
@@ -66,6 +66,9 @@ your ambitious dreams (if you dreams include this sort of thing).
     both are enabled. 
     *   Plugin actions may also explicitely reply in threads with/without
         broadcasting via [AnswerOption](answer.go)
+
+*   Concurrent processing of unrelated messages with guarantees of proper 
+    ordering of message updates/deletions
 
 *   Simple extensible storage `API` for persistence in two flavors: 
     `StringStorer` and `BytesStorer`. Both are basic `key:value` maps. 

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,7 @@ const (
 
 // Advanced configuration keys, only change if you really know what you're doing and have reviewed the internals
 const (
-	MessageProcessingPartitionCount       = "advanced.messageProcessingPartitionCount"       // The number of partitions used to process messages concurrently. A higher number means less chance (but higher resource usage) of delays in processing of different messages
+	MessageProcessingPartitionCount       = "advanced.messageProcessingPartitionCount"       // The number of partitions used to process messages concurrently. Must be a power of two. A higher number means less chance (but higher resource usage) of delays in processing of different messages
 	MessageProcessingBufferedMessageCount = "advanced.messageProcessingBufferedMessageCount" // The channel capacity of each message processing partition. A higher number means less chance of a given partition with a lot of slow messages to handle causing a blockage of processing on other partitions
 )
 
@@ -35,7 +35,7 @@ const (
 	threadedRepliesDefault                   = false
 	broadcastThreadedRepliesDefault          = false
 	maxAgeHandledMessagesDefault             = time.Duration(24) * time.Hour
-	msgProcessingPartitionCountDefault       = 1
+	msgProcessingPartitionCountDefault       = 16
 	msgProcessingBufferedMessageCountDefault = 10
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -21,14 +21,22 @@ const (
 	UserInfoCacheSizeKey        = "userInfoCacheSize"                      // The number of entries to keep in the user info cache, int value. Defaults to no caching (value of 0)
 )
 
+// Advanced configuration keys, only change if you really know what you're doing and have reviewed the internals
+const (
+	MessageProcessingPartitionCount       = "advanced.messageProcessingPartitionCount"       // The number of partitions used to process messages concurrently. A higher number means less chance (but higher resource usage) of delays in processing of different messages
+	MessageProcessingBufferedMessageCount = "advanced.messageProcessingBufferedMessageCount" // The channel capacity of each message processing partition. A higher number means less chance of a given partition with a lot of slow messages to handle causing a blockage of processing on other partitions
+)
+
 // Configuration defaults
 const (
-	debugDefault                    = false
-	responseCacheSizeDefault        = 5000
-	timeLocationDefault             = "Local"
-	threadedRepliesDefault          = false
-	broadcastThreadedRepliesDefault = false
-	maxAgeHandledMessagesDefault    = time.Duration(24) * time.Hour
+	debugDefault                             = false
+	responseCacheSizeDefault                 = 5000
+	timeLocationDefault                      = "Local"
+	threadedRepliesDefault                   = false
+	broadcastThreadedRepliesDefault          = false
+	maxAgeHandledMessagesDefault             = time.Duration(24) * time.Hour
+	msgProcessingPartitionCountDefault       = 1
+	msgProcessingBufferedMessageCountDefault = 10
 )
 
 // ReplyBehavior holds flags to define the replying behavior (use threads or not and broadcast replies or not)
@@ -49,6 +57,8 @@ func NewViperWithDefaults() (v *viper.Viper) {
 	v.SetDefault(ThreadedRepliesKey, threadedRepliesDefault)
 	v.SetDefault(BroadcastThreadedRepliesKey, broadcastThreadedRepliesDefault)
 	v.SetDefault(MaxAgeHandledMessages, maxAgeHandledMessagesDefault)
+	v.SetDefault(MessageProcessingPartitionCount, msgProcessingPartitionCountDefault)
+	v.SetDefault(MessageProcessingBufferedMessageCount, msgProcessingBufferedMessageCountDefault)
 
 	return v
 }

--- a/doc.go
+++ b/doc.go
@@ -5,12 +5,16 @@ It is easily extendable via plugins that can combine commands, hear actions (lis
 as scheduled actions. It also supports updating of triggered responses on message updates as well
 as deleting triggered responses when the triggering messages are deleted by users.
 
+Additionally, slackscot supports concurrent processing of messages. It also guarantees that updates
+and deletions of messages are processed in order relative to the original message they refer to.
+
 Plugins also have access to services injected on startup by slackscot such as:
  - UserInfoFinder: To query user info
  - SLogger: To log debug/info statements
  - EmojiReactor: To emoji react to messages
  - FileUploader: To upload files
  - RealTimeMessageSender: To send unmanaged real time messages outside the normal reaction flow (i.e. for sending many messages or sending via a scheduled action)
+ - SlackClient: For advanced access to all the slack APIs via https://godoc.org/github.com/nlopes/slack#Client
 
 Example code (from https://github.com/alexandre-normand/youppi):
 

--- a/fileuploader.go
+++ b/fileuploader.go
@@ -31,7 +31,7 @@ type UploadOption func(params *slack.FileUploadParameters)
 // the incoming message triggering this is on an existing thread
 func UploadInThreadOption(m *IncomingMessage) UploadOption {
 	return func(p *slack.FileUploadParameters) {
-		if threadTimestamp, inThread := resolveThreadTimestamp(&m.Msg); inThread {
+		if threadTimestamp, inThread := resolveThreadTimestamp(m.Msg); inThread {
 			p.ThreadTimestamp = threadTimestamp
 		}
 	}

--- a/routing.go
+++ b/routing.go
@@ -1,0 +1,90 @@
+package slackscot
+
+import (
+	"fmt"
+	"github.com/nlopes/slack"
+	"hash"
+	"hash/fnv"
+	"math"
+)
+
+type partitionRouter struct {
+	// Logger
+	log *sLogger
+
+	// messageQueues with partition keyed by the hash of the incoming message id
+	// so that processing of messages (new, updates and deletes) are handled by
+	// the same work queue therefore ensuring correct ordered processing
+	// of those events
+	messageQueues []chan slack.MessageEvent
+
+	// workerTerminationSignals are channels receiving a termination signal for each
+	// workerQueue
+	workerTerminationSignals []chan bool
+
+	// hash function to direct message processing to partitions
+	hasher   hash.Hash32
+	hashMask int
+}
+
+func newPartitionRouter(partitionCount int, queueBufferSize int, log *sLogger) (pr *partitionRouter, err error) {
+	if !isPowerOfTwo(partitionCount) {
+		return nil, fmt.Errorf("A partition router can only work with a partitionCount that is a power of two but was [%d]", partitionCount)
+	}
+
+	pr = new(partitionRouter)
+	pr.messageQueues = make([]chan slack.MessageEvent, partitionCount)
+	for i := range pr.messageQueues {
+		pr.messageQueues[i] = make(chan slack.MessageEvent, queueBufferSize)
+	}
+	pr.workerTerminationSignals = make([]chan bool, partitionCount)
+	for i := range pr.workerTerminationSignals {
+		pr.workerTerminationSignals[i] = make(chan bool)
+	}
+	pr.hasher = fnv.New32a()
+	pr.hashMask = hashMask(partitionCount)
+	pr.log = log
+
+	return pr, nil
+}
+
+// routeMessageEvent routes the message processing to the correct partition based on its original message id to ensure
+// that all message and its updates are processed in order
+func (pr *partitionRouter) routeMessageEvent(msgEvent slack.MessageEvent) {
+	msgID := getOriginalMessageID(msgEvent)
+
+	partition := pr.partitionForMsgID(msgID)
+
+	pr.log.Debugf("Dispatching message [%s] to partition [%d]", msgID, partition)
+	pr.messageQueues[partition] <- msgEvent
+}
+
+// partitionForMsgID returns the partition index for a given message ID
+func (pr *partitionRouter) partitionForMsgID(msgID SlackMessageID) (partition int) {
+	pr.hasher.Reset()
+	pr.hasher.Write([]byte(msgID.channelID))
+	pr.hasher.Write([]byte(msgID.timestamp))
+	res := pr.hasher.Sum32()
+
+	pr.log.Debugf("Hash [%d] calculated for [%s]", res, msgID)
+
+	// Keep only the rightmost bits so we have a max equal to the partition count
+	return int(res) & pr.hashMask
+}
+
+// isPowerOfTwo returns true if val is a power of two or false if not
+func isPowerOfTwo(val int) bool {
+	return (val != 0) && (val&(val-1)) == 0
+}
+
+// hashMask builds a mask for a partitionCount (which should be a power of two) to get a hash value
+// that is in the range of the number of partitions we have
+func hashMask(partitionCount int) int {
+	maskSize := int(math.Log2(float64(partitionCount)))
+	mask := 0
+	for i := 0; i < maskSize; i++ {
+		mask = mask<<1 | 1
+	}
+
+	return mask
+}

--- a/routing.go
+++ b/routing.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/nlopes/slack"
 	"hash"
-	"hash/fnv"
+	"hash/crc32"
 	"math"
 )
 
@@ -41,7 +41,7 @@ func newPartitionRouter(partitionCount int, queueBufferSize int, log *sLogger) (
 	for i := range pr.workerTerminationSignals {
 		pr.workerTerminationSignals[i] = make(chan bool)
 	}
-	pr.hasher = fnv.New32a()
+	pr.hasher = crc32.NewIEEE()
 	pr.hashMask = hashMask(partitionCount)
 	pr.log = log
 

--- a/routing_test.go
+++ b/routing_test.go
@@ -1,0 +1,128 @@
+package slackscot
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"log"
+	"math"
+	"os"
+	"testing"
+)
+
+func TestNewPartitioner(t *testing.T) {
+	tests := map[string]struct {
+		partitionCount int
+		expectedError  string
+	}{
+		"InvalidZeroPartitions": {
+			partitionCount: 0,
+			expectedError:  "A partition router can only work with a partitionCount that is a power of two but was [0]",
+		},
+		"ValidOnePartition": {
+			partitionCount: 1,
+			expectedError:  "",
+		},
+		"ValidTwoPartitions": {
+			partitionCount: 2,
+			expectedError:  "",
+		},
+		"Invalid3Partitions": {
+			partitionCount: 3,
+			expectedError:  "A partition router can only work with a partitionCount that is a power of two but was [3]",
+		},
+		"Valid4Partitions": {
+			partitionCount: 4,
+			expectedError:  "",
+		},
+		"Invalid5Partitions": {
+			partitionCount: 5,
+			expectedError:  "A partition router can only work with a partitionCount that is a power of two but was [5]",
+		},
+		"Valid8Partitions": {
+			partitionCount: 8,
+			expectedError:  "",
+		},
+		"Valid16Partitions": {
+			partitionCount: 16,
+			expectedError:  "",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			pr, err := newPartitionRouter(tc.partitionCount, 1, nil)
+
+			if tc.expectedError == "" {
+				assert.NoError(t, err)
+				assert.NotNil(t, pr)
+				assert.Len(t, pr.messageQueues, tc.partitionCount)
+				assert.Len(t, pr.workerTerminationSignals, tc.partitionCount)
+			} else {
+				assert.EqualError(t, err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestConsistentHashing(t *testing.T) {
+	msgID := SlackMessageID{channelID: "general", timestamp: "11298321983.23"}
+
+	for i := 0; i < 16; i++ {
+		partitionCount := int(math.Pow(float64(2), float64(i)))
+		name := fmt.Sprintf("With_%d_Partitions", partitionCount)
+
+		t.Run(name, func(t *testing.T) {
+			pr, _ := newPartitionRouter(partitionCount, 1, &sLogger{logger: log.New(os.Stdout, "", log.LstdFlags)})
+			partition := pr.partitionForMsgID(msgID)
+
+			for i := 0; i < 100; i++ {
+				assert.Equal(t, partition, pr.partitionForMsgID(msgID))
+			}
+		})
+	}
+}
+
+func TestHashDistribution(t *testing.T) {
+	// Generate message IDs that are all different to validate the uniform distribution accross partitions
+	msgIDs := make([]SlackMessageID, 0)
+	for i := 0; i < 500000; i++ {
+		msgTimestamp := fmt.Sprintf("19292929%d.214", i*1000)
+		msgIDs = append(msgIDs, SlackMessageID{channelID: "general", timestamp: msgTimestamp})
+		msgIDs = append(msgIDs, SlackMessageID{channelID: "général", timestamp: msgTimestamp})
+	}
+
+	msgIDCount := len(msgIDs)
+
+	for i := 0; i < 10; i++ {
+		partitionCount := int(math.Pow(float64(2), float64(i)))
+		name := fmt.Sprintf("With_%d_Partitions", partitionCount)
+		partitionHitCount := make([]int, partitionCount)
+
+		t.Run(name, func(t *testing.T) {
+			pr, _ := newPartitionRouter(partitionCount, 1, &sLogger{logger: log.New(os.Stdout, "", log.LstdFlags)})
+
+			for _, msgID := range msgIDs {
+				partition := pr.partitionForMsgID(msgID)
+				partitionHitCount[partition] = partitionHitCount[partition] + 1
+			}
+
+			expectedHitsPerPartition := float64(msgIDCount) / float64(partitionCount)
+			deviationTolerance := 3.0 * expectedHitsPerPartition / 100
+			for partition, hitCount := range partitionHitCount {
+				assert.InDeltaf(t, expectedHitsPerPartition, hitCount, deviationTolerance, "All partitions should have received about [%.1f] hits but partition [%d] got [%d]", expectedHitsPerPartition, partition, hitCount)
+			}
+		})
+	}
+}
+
+func TestHashMask(t *testing.T) {
+	for i := 0; i < 16; i++ {
+		partitionCount := int(math.Pow(float64(2), float64(i)))
+		name := fmt.Sprintf("With_%d_Partitions", partitionCount)
+
+		t.Run(name, func(t *testing.T) {
+			mask := hashMask(partitionCount)
+			assert.Equal(t, partitionCount-1, mask)
+		})
+	}
+}

--- a/slackscot.go
+++ b/slackscot.go
@@ -185,7 +185,7 @@ func (sid SlackMessageID) IsMsgModifiable() bool {
 
 // String returns the string representation of a SlackMessageID
 func (sid SlackMessageID) String() string {
-	return fmt.Sprintf("%s-%s", sid.channelID, sid.timestamp)
+	return fmt.Sprintf("%s/%s", sid.channelID, sid.timestamp)
 }
 
 // responseStrategy defines how a slack.OutgoingMessage is generated from an Answer

--- a/slackscot.go
+++ b/slackscot.go
@@ -320,9 +320,7 @@ func New(name string, v *viper.Viper, options ...Option) (s *Slackscot, err erro
 	s.namespaceCommands = true
 	s.testMode = false
 	s.closers = make([]io.Closer, 0)
-	s.defaultAction = func(m *IncomingMessage) *Answer {
-		return &Answer{Text: fmt.Sprintf("I don't understand. Ask me for \"%s\" to get a list of things I do", helpPluginName)}
-	}
+	s.defaultAction = defaultAction
 	s.log = NewSLogger(log.New(os.Stdout, defaultLogPrefix, defaultLogFlag), v.GetBool(config.DebugKey))
 
 	partitionCount := s.config.GetInt(config.MessageProcessingPartitionCount)
@@ -344,6 +342,11 @@ func New(name string, v *viper.Viper, options ...Option) (s *Slackscot, err erro
 	}
 
 	return s, nil
+}
+
+// defaultAnswer for a message directed to slackscot that isn't matching any known plugin command
+func defaultAction(m *IncomingMessage) *Answer {
+	return &Answer{Text: fmt.Sprintf("I don't understand. Ask me for \"%s\" to get a list of things I do", helpPluginName)}
 }
 
 // Close closes all closers of this slackscot. The first error that occurs

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -1062,10 +1062,6 @@ func TestPartitionCountConfigurations(t *testing.T) {
 		},
 	}
 
-	v := config.NewViperWithDefaults()
-	v.Set(config.MessageProcessingPartitionCount, 2)
-	v.Set(config.DebugKey, true)
-
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			v := config.NewViperWithDefaults()

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -1167,6 +1167,10 @@ func TestConcurrentProcessingOfNonRelatedMessages(t *testing.T) {
 	}
 }
 
+func TestSlackMessageIDStringer(t *testing.T) {
+	assert.Equal(t, "channel/2324", SlackMessageID{"channel", "2324"}.String())
+}
+
 func newRTMMessageEvent(msgEvent *slack.MessageEvent) (e slack.RTMEvent) {
 	e.Type = "message"
 	e.Data = msgEvent


### PR DESCRIPTION
## What is this about
This intends to address the use-case described by @pmcintyresfdc in issue #145. 

This is still a big rough and I'll be pushing updates in the coming days but wanted to get something out to show you, @pmcintyresfdc. 

TODO: 
 * [x] Move hashing-related functions and write missing table tests for those. 
 * [x] Review the godoc to make sure it's clear enough to users that might want to play with this advanced configuration. 
 * [x]  I'd also like to comment on the main test that proves this works since it might not be obvious to me or others what's going on if we ever have to revisit later.
 * [x] Add some timeout to the new test since someone that would break the parallel processing of messages would end up having that test hang and that wouldn't be easy to troubleshoot if I'm not providing a descriptive error message. 

That said, I have that good robust test that makes me feel confident with this implementation. 

And thanks to @coderunner for having inspired the partition hashing scheme from previous work done together. I think this nice feature doesn't look too bad as far as maintenance cost goes. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass