### PR TITLE
🐍 Apply Slackscot Defaults to any user-provided Viper Instance

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,17 @@ func NewViperWithDefaults() (v *viper.Viper) {
 	return v
 }
 
+// LayerConfigWithDefaults takes a loaded user configuration and layers the defaults under it
+func LayerConfigWithDefaults(v *viper.Viper) (layered *viper.Viper) {
+	defaults := NewViperWithDefaults()
+
+	for defaultKey, defaultVal := range defaults.AllSettings() {
+		v.SetDefault(defaultKey, defaultVal)
+	}
+
+	return v
+}
+
 // GetTimeLocation reads the TimeLocation configuration and maps it to the appropriate time.Location value. Returns an err if the location value is invalid
 func GetTimeLocation(v *viper.Viper) (timeLoc *time.Location, err error) {
 	locationId := v.GetString(TimeLocationKey)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,6 +17,38 @@ func TestNewWithDefault(t *testing.T) {
 	assert.Equal(t, false, v.GetBool(config.ThreadedRepliesKey), "%s should be %t", config.ThreadedRepliesKey, false)
 	assert.Equal(t, false, v.GetBool(config.BroadcastThreadedRepliesKey), "%s should be %t", config.BroadcastThreadedRepliesKey, false)
 	assert.Equal(t, time.Duration(24)*time.Hour, v.GetDuration(config.MaxAgeHandledMessages), "%s should be %t", config.MaxAgeHandledMessages, time.Duration(24)*time.Hour)
+	assert.Equal(t, 16, v.GetInt(config.MessageProcessingPartitionCount), "%s should be %d", config.MessageProcessingPartitionCount, 16)
+	assert.Equal(t, 10, v.GetInt(config.MessageProcessingBufferedMessageCount), "%s should be %d", config.MessageProcessingBufferedMessageCount, 10)
+}
+
+func TestLayerConfigWithDefaults(t *testing.T) {
+	v := viper.New()
+
+	for key, _ := range config.NewViperWithDefaults().AllSettings() {
+		assert.Nil(t, v.Get(key))
+	}
+
+	v = config.LayerConfigWithDefaults(v)
+	for key, expectedVal := range config.NewViperWithDefaults().AllSettings() {
+		assert.Equal(t, expectedVal, v.Get(key), "%s should be %v", key, expectedVal)
+	}
+}
+
+func TestLayeredConfigWithDefaultsAndOverrides(t *testing.T) {
+	v := viper.New()
+	v = config.LayerConfigWithDefaults(v)
+	v.Set(config.MessageProcessingPartitionCount, 32)
+	v.Set(config.MessageProcessingBufferedMessageCount, 20)
+
+	v = config.LayerConfigWithDefaults(v)
+	for key, expectedVal := range config.NewViperWithDefaults().AllSettings() {
+		if key != "advanced" {
+			assert.Equal(t, expectedVal, v.Get(key), "%s should be %v", key, expectedVal)
+		}
+	}
+
+	assert.Equal(t, 32, v.GetInt(config.MessageProcessingPartitionCount), "%s should be %v", config.MessageProcessingPartitionCount, 32)
+	assert.Equal(t, 20, v.GetInt(config.MessageProcessingBufferedMessageCount), "%s should be %v", config.MessageProcessingBufferedMessageCount, 20)
 }
 
 func TestGetTimeLocationWithDefault(t *testing.T) {

--- a/slackscot.go
+++ b/slackscot.go
@@ -315,6 +315,7 @@ func New(name string, v *viper.Viper, options ...Option) (s *Slackscot, err erro
 		return nil, err
 	}
 
+	v = config.LayerConfigWithDefaults(v)
 	s.name = name
 	s.config = v
 	s.namespaceCommands = true

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.38.0"
+	VERSION = "1.39.0"
 )


### PR DESCRIPTION
## What is this about
This applies all slackscot configuration defaults to any user provided configuration regardless of whether the user considered creating an instance from `config.NewViperWithDefaults` or not. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass