### PR TITLE
🧘‍♂️ Simplify Karma Plugin and Only Support User Karma Recording

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nlopes/slack v0.6.1-0.20191106133607-d06c2a2b3249
 	github.com/pkg/errors v0.8.1
-	github.com/russross/blackfriday/v2 v2.0.1
 	github.com/spf13/cast v1.3.0
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,6 @@ github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7q
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
-github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
-github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=

--- a/plugins/karma.go
+++ b/plugins/karma.go
@@ -7,8 +7,7 @@ import (
 	"github.com/alexandre-normand/slackscot/plugin"
 	"github.com/alexandre-normand/slackscot/store"
 	"github.com/nlopes/slack"
-	"github.com/russross/blackfriday/v2"
-	"io"
+	"log"
 	"regexp"
 	"sort"
 	"strconv"
@@ -27,7 +26,7 @@ const (
 	defaultItemCount = 5
 )
 
-var karmaRegex = regexp.MustCompile("(?:\\A|\\W)(?:(?:<(@[\\w']+)>\\s?)|([\\w']+-?[\\w']+))(\\+{2,6}|\\-{2,6}).*")
+var karmaRegex = regexp.MustCompile("(?:\\A|\\W)(?:(<(@[\\w']+)>\\s?))(\\+{2,6}|\\-{2,6}).*")
 
 // Ranker represents attributes and behavior to process a ranking list
 type ranker struct {
@@ -123,55 +122,8 @@ func NewKarma(storer store.GlobalSiloStringStorer) (karma *slackscot.Plugin) {
 
 // matchKarmaRecord returns true if the message matches karma++ or karma-- (karma being any word)
 func matchKarmaRecord(m *slackscot.IncomingMessage) bool {
-	thing, _ := findFirstKarma(m)
-	return len(thing) > 0
-}
-
-// findFirstKarma returns the first karma thing in a message. It uses a markdown
-// parser to ignore anything that is part of a code block or inline code element
-func findFirstKarma(m *slackscot.IncomingMessage) (thing string, instruction string) {
-	tmr := new(textMatcherRenderer)
-	blackfriday.Run([]byte(m.NormalizedText), blackfriday.WithRenderer(tmr))
-
-	return tmr.thing, tmr.instruction
-}
-
-// textMatcherRenderer holds the first thing that matches in a markdown-parsed tree. It implements
-// the blackfriday.Renderer interface but doesn't actually do any rendering in the typical definition
-// except if you consider finding a karma record match in text nodes a rendering action
-type textMatcherRenderer struct {
-	thing       string
-	instruction string
-}
-
-// RenderNode looks at text nodes and tries to match a karma record instruction. As soon as a match is found, parsing
-// is terminated
-func (tp *textMatcherRenderer) RenderNode(w io.Writer, node *blackfriday.Node, entering bool) blackfriday.WalkStatus {
-	if node.Type == blackfriday.Text && len(tp.thing) == 0 {
-		matches := karmaRegex.FindStringSubmatch(string(node.Literal))
-		if len(matches) > 0 {
-			// Depending on if it's a user id or a "normal" thing, the matching group is different so we
-			// check both (only one can ever match)
-			tp.thing = matches[1]
-			if len(tp.thing) == 0 {
-				tp.thing = matches[2]
-			}
-
-			tp.instruction = matches[3]
-
-			return blackfriday.Terminate
-		}
-	}
-
-	return blackfriday.GoToNext
-}
-
-// RenderHeader is a no-op
-func (tp *textMatcherRenderer) RenderHeader(w io.Writer, ast *blackfriday.Node) {
-}
-
-// RenderFooter is a no-op
-func (tp *textMatcherRenderer) RenderFooter(w io.Writer, ast *blackfriday.Node) {
+	matches := karmaRegex.FindStringSubmatch(m.NormalizedText)
+	return len(matches) > 0
 }
 
 // matchKarmaTopReport returns true if the message matches a request for top karma with
@@ -207,8 +159,9 @@ func matchKarmaReset(m *slackscot.IncomingMessage) bool {
 // recordKarma records a karma increase or decrease and answers with a message including
 // the recorded word with its associated karma value
 func (k *Karma) recordKarma(message *slackscot.IncomingMessage) *slackscot.Answer {
-	thing, instruction := findFirstKarma(message)
+	match := karmaRegex.FindAllStringSubmatch(message.Text, -1)[0]
 
+	thing := match[2]
 	// Prevent a user from attributing karma to self
 	if strings.TrimPrefix(thing, "@") == message.User {
 		return &slackscot.Answer{Text: "*Attributing yourself karma is frown upon* :face_with_raised_eyebrow:", Options: []slackscot.AnswerOption{slackscot.AnswerEphemeral(message.User)}}
@@ -224,18 +177,20 @@ func (k *Karma) recordKarma(message *slackscot.IncomingMessage) *slackscot.Answe
 		karma = 0
 	}
 
+	log.Printf("thing is [%s]\n", thing)
 	answerText := ""
 	renderedThing := k.renderThing(thing)
 
+	instruction := match[3]
 	if strings.HasPrefix(instruction, "+") {
 		incrementSymbols := strings.TrimPrefix(instruction, "+")
 		increment := len(incrementSymbols)
 		karma = karma + increment
 
 		if increment == 1 {
-			answerText = fmt.Sprintf("`%s` just gained a level (`%s`: %d)", renderedThing, renderedThing, karma)
+			answerText = fmt.Sprintf("`%s` just gained karma (`%s`: %d)", renderedThing, renderedThing, karma)
 		} else {
-			answerText = fmt.Sprintf("`%s` just gained %d levels (`%s`: %d)", renderedThing, increment, renderedThing, karma)
+			answerText = fmt.Sprintf("`%s` just gained %d karma points (`%s`: %d)", renderedThing, increment, renderedThing, karma)
 		}
 
 	} else {
@@ -244,9 +199,9 @@ func (k *Karma) recordKarma(message *slackscot.IncomingMessage) *slackscot.Answe
 		karma = karma - decrement
 
 		if decrement == 1 {
-			answerText = fmt.Sprintf("`%s` just lost a life (`%s`: %d)", renderedThing, renderedThing, karma)
+			answerText = fmt.Sprintf("`%s` just lost karma (`%s`: %d)", renderedThing, renderedThing, karma)
 		} else {
-			answerText = fmt.Sprintf("`%s` just lost %d lives (`%s`: %d)", renderedThing, decrement, renderedThing, karma)
+			answerText = fmt.Sprintf("`%s` just lost %d karma points (`%s`: %d)", renderedThing, decrement, renderedThing, karma)
 		}
 	}
 

--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -30,50 +30,25 @@ func TestKarmaMatchesAndAnswers(t *testing.T) {
 		channel        string
 		expectedAnswer string
 	}{
-		{"creek++", "Cgeneral", "`creek` just gained a level (`creek`: 1)"},
-		{"creek--", "Cgeneral", "`creek` just lost a life (`creek`: 0)"},
-		{"the creek++", "Cgeneral", "`creek` just gained a level (`creek`: 1)"},
-		{"our creek++ is nice", "Cgeneral", "`creek` just gained a level (`creek`: 2)"},
-		{"our creek++ is really nice", "Cgeneral", "`creek` just gained a level (`creek`: 3)"},
-		{"oceans++", "Cgeneral", "`oceans` just gained a level (`oceans`: 1)"},
-		{"oceans++", "Cgeneral", "`oceans` just gained a level (`oceans`: 2)"},
-		{"nettle++", "Cgeneral", "`nettle` just gained a level (`nettle`: 1)"},
-		{"salmon++", "Cgeneral", "`salmon` just gained a level (`salmon`: 1)"},
-		{"salmon++", "Cgeneral", "`salmon` just gained a level (`salmon`: 2)"},
-		{"salmon++", "Cgeneral", "`salmon` just gained a level (`salmon`: 3)"},
-		{"salmon++", "Cgeneral", "`salmon` just gained a level (`salmon`: 4)"},
-		{"salmon+++", "Cgeneral", "`salmon` just gained 2 levels (`salmon`: 6)"},
-		{"salmon++++", "Cgeneral", "`salmon` just gained 3 levels (`salmon`: 9)"},
-		{"salmon+++++", "Cgeneral", "`salmon` just gained 4 levels (`salmon`: 13)"},
-		{"salmon++++++", "Cgeneral", "`salmon` just gained 5 levels (`salmon`: 18)"},
-		{"salmon+++++++", "Cgeneral", "`salmon` just gained 5 levels (`salmon`: 23)"},
-		{"dams--", "Cgeneral", "`dams` just lost a life (`dams`: -1)"},
-		{"dams--", "Cgeneral", "`dams` just lost a life (`dams`: -2)"},
-		{"dams---", "Cgeneral", "`dams` just lost 2 lives (`dams`: -4)"},
-		{"dams----", "Cgeneral", "`dams` just lost 3 lives (`dams`: -7)"},
-		{"dams-----", "Cgeneral", "`dams` just lost 4 lives (`dams`: -11)"},
-		{"dams------", "Cgeneral", "`dams` just lost 5 lives (`dams`: -16)"},
-		{"dams-------", "Cgeneral", "`dams` just lost 5 lives (`dams`: -21)"},
 		{"<@bot> karma", "Cgeneral", ""},
-		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 1)"},
-		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 2)"},
-		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 3)"},
-		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 4)"},
-		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 5)"},
-		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 6)"},
-		{"<@U21355> ++", "Cgeneral", "`Bernard Tremblay` just gained a level (`Bernard Tremblay`: 7)"},
-		{"thing ++", "Cgeneral", ""},
-		{"```block--```", "Cgeneral", ""},
-		{"`inlinecode--`", "Cgeneral", ""},
-		{"don't++", "Cgeneral", "`don't` just gained a level (`don't`: 1)"},
-		{"under-the-bridge++", "Cgeneral", "`the-bridge` just gained a level (`the-bridge`: 1)"},
-		{"Jean-Michel++", "Cgeneral", "`Jean-Michel` just gained a level (`Jean-Michel`: 1)"},
+		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained karma (`Bernard Tremblay`: 1)"},
+		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained karma (`Bernard Tremblay`: 2)"},
+		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained karma (`Bernard Tremblay`: 3)"},
+		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained karma (`Bernard Tremblay`: 4)"},
+		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained karma (`Bernard Tremblay`: 5)"},
+		{"<@U21355>++", "Cgeneral", "`Bernard Tremblay` just gained karma (`Bernard Tremblay`: 6)"},
+		{"<@U21355> ++", "Cgeneral", "`Bernard Tremblay` just gained karma (`Bernard Tremblay`: 7)"},
+		{"<@U21355>+++", "Cgeneral", "`Bernard Tremblay` just gained 2 karma points (`Bernard Tremblay`: 9)"},
+		{"<@U21355>++++", "Cgeneral", "`Bernard Tremblay` just gained 3 karma points (`Bernard Tremblay`: 12)"},
+		{"<@U21355>+++++", "Cgeneral", "`Bernard Tremblay` just gained 4 karma points (`Bernard Tremblay`: 16)"},
+		{"<@U21355>++++++", "Cgeneral", "`Bernard Tremblay` just gained 5 karma points (`Bernard Tremblay`: 21)"},
+		{"<@U21355>+++++++", "Cgeneral", "`Bernard Tremblay` just gained 5 karma points (`Bernard Tremblay`: 26)"},
 		{"+----------+", "Cgeneral", ""},
 		{"---", "Cgeneral", ""},
 		{"+++", "Cgeneral", ""},
-		{"salmon++", "Coceanlife", "`salmon` just gained a level (`salmon`: 1)"},
+		{"<@U21355>++", "Coceanlife", "`Bernard Tremblay` just gained karma (`Bernard Tremblay`: 1)"},
 		{"<@bot> top 1", "Cother", "Sorry, no recorded karma found :disappointed:"},
-		{"dams--", "Coceanlife", "`dams` just lost a life (`dams`: -1)"},
+		{"<@U21355>--", "Coceanlife", "`Bernard Tremblay` just lost karma (`Bernard Tremblay`: 0)"},
 		{"<@bot> reset", "Coceanlife", "karma all cleared :white_check_mark::boom:"},
 		{"<@bot> top 1", "Coceanlife", "Sorry, no recorded karma found :disappointed:"},
 	}
@@ -111,8 +86,8 @@ func TestErrorStoringKarmaRecord(t *testing.T) {
 	mockStorer := &mocks.Storer{}
 	defer mockStorer.AssertExpectations(t)
 
-	mockStorer.On("GetSiloString", "myLittleChannel", "thing").Return("", fmt.Errorf("not found"))
-	mockStorer.On("PutSiloString", "myLittleChannel", "thing", "1").Return(fmt.Errorf("can't persist"))
+	mockStorer.On("GetSiloString", "myLittleChannel", "@U21355").Return("", fmt.Errorf("not found"))
+	mockStorer.On("PutSiloString", "myLittleChannel", "@U21355", "1").Return(fmt.Errorf("can't persist"))
 
 	var userInfoFinder userInfoFinder
 	p := plugins.NewKarma(mockStorer)
@@ -120,7 +95,7 @@ func TestErrorStoringKarmaRecord(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "thing++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@U21355>++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
 		return assert.Empty(t, answers)
 	})
 }
@@ -135,8 +110,8 @@ func TestInvalidSelfKarma(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(p, &slack.Msg{User: "U123", Channel: "myLittleChannel", Text: "<@U123>++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "*Attributing yourself karma is frown upon* :face_with_raised_eyebrow:") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.EphemeralAnswerToOpt, Value: "U123"})
+	assertplugin.AnswersAndReacts(p, &slack.Msg{User: "U21355", Channel: "myLittleChannel", Text: "<@U21355>++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "*Attributing yourself karma is frown upon* :face_with_raised_eyebrow:") && assertanswer.HasOptions(t, answers[0], assertanswer.ResolvedAnswerOption{Key: slackscot.EphemeralAnswerToOpt, Value: "U21355"})
 	})
 }
 
@@ -144,8 +119,8 @@ func TestInvalidStoredKarmaShouldResetValue(t *testing.T) {
 	mockStorer := &mocks.Storer{}
 	defer mockStorer.AssertExpectations(t)
 
-	mockStorer.On("GetSiloString", "myLittleChannel", "thing").Return("abc", nil)
-	mockStorer.On("PutSiloString", "myLittleChannel", "thing", "1").Return(nil)
+	mockStorer.On("GetSiloString", "myLittleChannel", "@U21355").Return("abc", nil)
+	mockStorer.On("PutSiloString", "myLittleChannel", "@U21355", "1").Return(nil)
 
 	var userInfoFinder userInfoFinder
 	p := plugins.NewKarma(mockStorer)
@@ -153,8 +128,8 @@ func TestInvalidStoredKarmaShouldResetValue(t *testing.T) {
 
 	assertplugin := assertplugin.New(t, "bot")
 
-	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "thing++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
-		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "`thing` just gained a level (`thing`: 1)")
+	assertplugin.AnswersAndReacts(p, &slack.Msg{Channel: "myLittleChannel", Text: "<@U21355>++"}, func(t *testing.T, answers []*slackscot.Answer, emojis []string) bool {
+		return assert.Len(t, answers, 1) && assertanswer.HasText(t, answers[0], "`Bernard Tremblay` just gained karma (`Bernard Tremblay`: 1)")
 	})
 }
 

--- a/version.go
+++ b/version.go
@@ -3,5 +3,5 @@ package slackscot
 // GENERATED and MANAGED by giddyup (https://github.com/alexandre-normand/giddyup)
 const (
 	// VERSION represents the current slackscot version
-	VERSION = "1.39.0"
+	VERSION = "1.40.0"
 )


### PR DESCRIPTION
## What is this about
The `karma` plugin came from an old hubot-based plugin back when everything was pretty much just text with proper formalization of user ids. Also, based on the modern usages of `karma`, the desire seems to be mostly to give friends and colleagues karma and not so much to record score attributed to things or ideas. Lastly, the parsing to ignore potential false positives can be tricky and never perfect..which can add more noise than can be considered acceptable. 

For all those reasons, here's a change to simplify the `karma` plugin and only record user karma recording. As a nice benefit, this also cleans up `blackfriday` as a dependency which felt a bit heavyweight for parsing to ignore false positives in code blocks.. 

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass