### PR TITLE
Switched to slack-go/slack rather than nlopes old repo

### DIFF
--- a/answer.go
+++ b/answer.go
@@ -1,7 +1,7 @@
 package slackscot
 
 import (
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 )
 
 const (

--- a/chatdriver.go
+++ b/chatdriver.go
@@ -1,17 +1,17 @@
 package slackscot
 
 import (
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 )
 
 // RealTimeMessageSender is implemented by any value that has the NewOutgoingMessage method.
 // The main purpose is a slight decoupling of the slack.RTM in order for plugins to be able to write
 // tests more easily if all they do is send new messages on a channel
 type RealTimeMessageSender interface {
-	// NewOutgoingMessage is the function that creates a new message to send. See https://godoc.org/github.com/nlopes/slack#RTM.NewOutgoingMessage for more details
+	// NewOutgoingMessage is the function that creates a new message to send. See https://godoc.org/github.com/slack-go/slack#RTM.NewOutgoingMessage for more details
 	NewOutgoingMessage(text string, channelID string, options ...slack.RTMsgOption) *slack.OutgoingMessage
 
-	// SendMessage is the function that sends a new real time message. See https://godoc.org/github.com/nlopes/slack#RTM.SendMessage for more details
+	// SendMessage is the function that sends a new real time message. See https://godoc.org/github.com/slack-go/slack#RTM.SendMessage for more details
 	SendMessage(outMsg *slack.OutgoingMessage)
 }
 

--- a/chatdrivermetrics.go
+++ b/chatdrivermetrics.go
@@ -11,7 +11,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/metric"
 )

--- a/doc.go
+++ b/doc.go
@@ -17,7 +17,7 @@ Plugins also have access to services injected on startup by slackscot such as:
  - EmojiReactor: To emoji react to messages
  - FileUploader: To upload files
  - RealTimeMessageSender: To send unmanaged real time messages outside the normal reaction flow (i.e. for sending many messages or sending via a scheduled action)
- - SlackClient: For advanced access to all the slack APIs via https://godoc.org/github.com/nlopes/slack#Client
+ - SlackClient: For advanced access to all the slack APIs via https://godoc.org/github.com/slack-go/slack#Client
 
 Example code (from https://github.com/alexandre-normand/youppi):
 

--- a/emojireactor.go
+++ b/emojireactor.go
@@ -1,7 +1,7 @@
 package slackscot
 
 import (
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 )
 
 // EmojiReactor is implemented by any value that has the AddReaction method.

--- a/emojireactormetrics.go
+++ b/emojireactormetrics.go
@@ -11,7 +11,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/metric"
 )

--- a/fileuploader.go
+++ b/fileuploader.go
@@ -1,7 +1,7 @@
 package slackscot
 
 import (
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 )
 
 // SlackFileUploader is implemented by any value that has the UploadFile method. slack.Client
@@ -9,7 +9,7 @@ import (
 // for plugins to be able to write cleaner tests more easily.
 type SlackFileUploader interface {
 	// UploadFile uploads a file to slack. For more info in this API, check
-	// https://godoc.org/github.com/nlopes/slack#Client.UploadFile
+	// https://godoc.org/github.com/slack-go/slack#Client.UploadFile
 	UploadFile(params slack.FileUploadParameters) (file *slack.File, err error)
 }
 
@@ -20,7 +20,7 @@ type SlackFileUploader interface {
 // be able to write cleaner tests more easily.
 type FileUploader interface {
 	// UploadFile uploads a file to slack. For more info in this API, check
-	// https://godoc.org/github.com/nlopes/slack#Client.UploadFile
+	// https://godoc.org/github.com/slack-go/slack#Client.UploadFile
 	UploadFile(params slack.FileUploadParameters, options ...UploadOption) (file *slack.File, err error)
 }
 

--- a/fileuploader_test.go
+++ b/fileuploader_test.go
@@ -3,7 +3,7 @@ package slackscot_test
 import (
 	"github.com/alexandre-normand/slackscot"
 	"github.com/alexandre-normand/slackscot/test/capture"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/fileuploadermetrics.go
+++ b/fileuploadermetrics.go
@@ -11,7 +11,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/metric"
 )

--- a/go.mod
+++ b/go.mod
@@ -11,11 +11,11 @@ require (
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.11 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/nlopes/slack v0.6.1-0.20191106133607-d06c2a2b3249
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/pelletier/go-toml v1.5.0 // indirect
 	github.com/pkg/errors v0.8.1
+	github.com/slack-go/slack v0.6.3
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cast v1.3.0
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
+github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
@@ -113,8 +115,7 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nlopes/slack v0.6.1-0.20191106133607-d06c2a2b3249 h1:Pr5gZa2VcmktVwq0lyC39MsN5tz356vC/pQHKvq+QBo=
-github.com/nlopes/slack v0.6.1-0.20191106133607-d06c2a2b3249/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
+github.com/nlopes/slack v0.6.0/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
@@ -151,6 +152,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/slack-go/slack v0.6.3 h1:qU037g8gQ71EuH6S9zYKnvYrEUj0fLFH4HFekFqBoRU=
+github.com/slack-go/slack v0.6.3/go.mod h1:HE4RwNe7YpOg/F0vqo5PwXH3Hki31TplTvKRW9dGGaw=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=

--- a/help_internal_test.go
+++ b/help_internal_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/alexandre-normand/slackscot/config"
 	"github.com/alexandre-normand/slackscot/schedule"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"strings"

--- a/plugins/emojibanner_test.go
+++ b/plugins/emojibanner_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/alexandre-normand/slackscot/plugins"
 	"github.com/alexandre-normand/slackscot/test/assertanswer"
 	"github.com/alexandre-normand/slackscot/test/assertplugin"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/plugins/fingerquoter_test.go
+++ b/plugins/fingerquoter_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/alexandre-normand/slackscot/plugins"
 	"github.com/alexandre-normand/slackscot/test/assertanswer"
 	"github.com/alexandre-normand/slackscot/test/assertplugin"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"log"

--- a/plugins/karma.go
+++ b/plugins/karma.go
@@ -6,7 +6,7 @@ import (
 	"github.com/alexandre-normand/slackscot/actions"
 	"github.com/alexandre-normand/slackscot/plugin"
 	"github.com/alexandre-normand/slackscot/store"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"log"
 	"regexp"
 	"sort"

--- a/plugins/karma_test.go
+++ b/plugins/karma_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/alexandre-normand/slackscot/store/mocks"
 	"github.com/alexandre-normand/slackscot/test/assertanswer"
 	"github.com/alexandre-normand/slackscot/test/assertplugin"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"

--- a/plugins/ohmonday_test.go
+++ b/plugins/ohmonday_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/alexandre-normand/slackscot/plugins"
 	"github.com/alexandre-normand/slackscot/schedule"
 	"github.com/alexandre-normand/slackscot/test/assertplugin"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"testing"

--- a/plugins/triggerer.go
+++ b/plugins/triggerer.go
@@ -8,7 +8,7 @@ import (
 	"github.com/alexandre-normand/slackscot/actions"
 	"github.com/alexandre-normand/slackscot/plugin"
 	"github.com/alexandre-normand/slackscot/store"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"regexp"
 	"sort"
 	"strings"

--- a/plugins/triggerer_test.go
+++ b/plugins/triggerer_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/alexandre-normand/slackscot/store/mocks"
 	"github.com/alexandre-normand/slackscot/test/assertanswer"
 	"github.com/alexandre-normand/slackscot/test/assertplugin"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 	"log"
 	"strings"

--- a/plugins/versionner_test.go
+++ b/plugins/versionner_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/alexandre-normand/slackscot/plugins"
 	"github.com/alexandre-normand/slackscot/test/assertanswer"
 	"github.com/alexandre-normand/slackscot/test/assertplugin"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/routing.go
+++ b/routing.go
@@ -3,7 +3,7 @@ package slackscot
 import (
 	"context"
 	"fmt"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"hash"
 	"hash/crc32"
 	"math"

--- a/slackscot.go
+++ b/slackscot.go
@@ -7,7 +7,7 @@ import (
 	"github.com/alexandre-normand/slackscot/schedule"
 	"github.com/hashicorp/golang-lru"
 	"github.com/marcsantiago/gocron"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"github.com/spf13/cast"
 	"github.com/spf13/viper"
 	opentelemetry "go.opentelemetry.io/otel/api/global"
@@ -117,8 +117,8 @@ type Plugin struct {
 	FileUploader      FileUploader
 	RealTimeMsgSender RealTimeMessageSender
 
-	// The slack.Client is injected post-creation. It gives access to all the https://godoc.org/github.com/nlopes/slack#Client.
-	// Plugin writers might want to check out https://godoc.org/github.com/nlopes/slack/slacktest to create a slack test server in order
+	// The slack.Client is injected post-creation. It gives access to all the https://godoc.org/github.com/slack-go/slack#Client.
+	// Plugin writers might want to check out https://godoc.org/github.com/slack-go/slack/slacktest to create a slack test server in order
 	// to mock a slack server to test plugins using the SlackClient.
 	SlackClient *slack.Client
 }
@@ -317,7 +317,7 @@ func OptionLogfile(logfile *os.File) Option {
 }
 
 // OptionTestMode sets the instance in test mode which instructs it to react to a goodbye event to terminate
-// its execution. It is meant to be used for testing only and mostly in conjunction with github.com/nlopes/slack/slacktest.
+// its execution. It is meant to be used for testing only and mostly in conjunction with github.com/slack-go/slack/slacktest.
 // Very importantly, the termination message must be formed correctly so that the slackscot instance terminates
 // correctly for tests to actually terminate.
 //

--- a/slackscot_test.go
+++ b/slackscot_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/alexandre-normand/slackscot/schedule"
 	"github.com/alexandre-normand/slackscot/test/capture"
 	"github.com/gorilla/websocket"
-	"github.com/nlopes/slack"
-	"github.com/nlopes/slack/slacktest"
+	"github.com/slack-go/slack"
+	"github.com/slack-go/slack/slacktest"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1289,7 +1289,6 @@ func sendTestEventsForProcessing(ec chan<- slack.RTMEvent, events []slack.RTMEve
 	// Terminate the sequence of test events by sending a termination event
 	ec <- slack.RTMEvent{"disconnected", &slack.DisconnectedEvent{Intentional: true, Cause: slack.ErrRTMGoodbye}}
 }
-
 
 func TestCommandMatcherOverride(t *testing.T) {
 	sentMsgs, _, _, _ := runSlackscotWithIncomingEvents(t, nil, newTestPlugin(), []slack.RTMEvent{

--- a/test/assertplugin/assertplugin.go
+++ b/test/assertplugin/assertplugin.go
@@ -5,7 +5,7 @@ import (
 	"github.com/alexandre-normand/slackscot"
 	"github.com/alexandre-normand/slackscot/schedule"
 	"github.com/alexandre-normand/slackscot/test/capture"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 	"log"
 	"strings"

--- a/test/assertplugin/assertplugin_test.go
+++ b/test/assertplugin/assertplugin_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/alexandre-normand/slackscot/schedule"
 	"github.com/alexandre-normand/slackscot/test/assertanswer"
 	"github.com/alexandre-normand/slackscot/test/assertplugin"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
 	"log"
 	"strings"

--- a/test/capture/emojireactioncaptor.go
+++ b/test/capture/emojireactioncaptor.go
@@ -2,7 +2,7 @@ package capture
 
 import (
 	"fmt"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 )
 
 // EmojiReactionCaptor captures emoji reactions recorded by

--- a/test/capture/fileuploadcaptor.go
+++ b/test/capture/fileuploadcaptor.go
@@ -1,7 +1,7 @@
 package capture
 
 import (
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"strconv"
 	"time"
 )

--- a/test/capture/sendercaptor.go
+++ b/test/capture/sendercaptor.go
@@ -1,7 +1,7 @@
 package capture
 
 import (
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 )
 
 // RealTimeSenderCaptor holds messages sent to it keyed

--- a/user.go
+++ b/user.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/alexandre-normand/slackscot/config"
 	"github.com/hashicorp/golang-lru"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"github.com/spf13/viper"
 )
 

--- a/user_test.go
+++ b/user_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/alexandre-normand/slackscot"
 	"github.com/alexandre-normand/slackscot/config"
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"log"

--- a/userinfofindermetrics.go
+++ b/userinfofindermetrics.go
@@ -11,7 +11,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/nlopes/slack"
+	"github.com/slack-go/slack"
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/api/metric"
 )


### PR DESCRIPTION
## What is this about
Using the new slack-go/slack repo

### Checklist
*   [x] I've reviewed my own code
*   [x] I've executed `go build ./...` and confirmed the build passes
*   [x] I've run `go test ./...` and confirmed the tests pass